### PR TITLE
Wire dead code, add PostgreSQL backend, fix 8 review issues, update a…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-NeuroSync is a developer-focused memory MCP server (v0.4.0). It provides episodic, semantic, and working memory — plus cognitive features (hierarchy, forgetting, analogy, causal reasoning, failure modeling) — for AI coding agents via 10 MCP tools.
+NeuroSync is a developer-focused memory MCP server (v0.5.0). It provides episodic, semantic, and working memory — plus cognitive features (hierarchy, forgetting, analogy, causal reasoning, failure modeling, user familiarity tracking) — for AI coding agents via 10 MCP tools. Supports SQLite (default) and PostgreSQL backends.
 
 ## NeuroSync Memory Protocol
 
@@ -37,7 +37,11 @@ Call `neurosync_record` with structured episodes when the session ends. Write ca
 
 ### What's automatic
 
-- **Auto-consolidation** — theories are extracted automatically when enough episodes accumulate (no manual `consolidate` needed)
+- **Auto-consolidation** — theories are extracted automatically when enough episodes accumulate (no manual `consolidate` needed). Uses TF-IDF keyword extraction and multi-episode merge heuristics (zero LLM tokens).
+- **Forgetting pass** — after consolidation, Ebbinghaus retention curves prune low-value episodes and decay stale theories
+- **User familiarity tracking** — topics you know well are suppressed from recall; corrections reduce familiarity
+- **7 active signal types** — CORRECTION (2^N), DEPTH (layer count), SURPRISE (contradicts theory), REPETITION (re-explained), EXPLICIT (x10), INTUITION (1-5), PASSIVE (x0.3). DURATION is defined but not yet wired (requires session-level timing).
+- **Outcome-based confidence** — session correction count adjusts recalled theory confidence
 - **Passive git observation** — file changes and commits are recorded as low-weight episodes automatically
 - **Dynamic hints** — tool responses include contextual guidance
 
@@ -48,19 +52,20 @@ Call `neurosync_record` with structured episodes when the session ends. Write ca
   - `cli.py` — CLI commands: serve, consolidate, status, import-starter-pack, generate-protocol, install-hook, graph-sync, graph-status, reset
   - `config.py` — Configuration (env > config.json > defaults)
   - `models.py` — Dataclasses (Session, Episode, Signal, Theory, Contradiction, UserKnowledge)
-  - `db.py` — SQLite database (WAL mode, thread-safe, schema migrations)
+  - `db.py` — SQLite database (WAL mode, thread-safe, schema migrations) — default backend
+  - `pg_db.py` — PostgreSQL database (connection pooling, JSONB) — optional backend
   - `vectorstore.py` — ChromaDB wrapper (episodes + theories collections)
   - `episodic.py` — Layer 1: session/episode CRUD, causal episodes, continuations
   - `semantic.py` — Layer 2: theory CRUD, confidence, linking, validation tracking
   - `working.py` — Layer 3: recall with winner-take-all, continuation priority
+  - `retrieval.py` — Full recall pipeline with user familiarity filtering and parent context
+  - `user_model.py` — Topic familiarity tracking, meta-learning (correction rate per topic)
   - `consolidation.py` — Consolidation engine: cluster -> extract -> MDL prune -> auto-linking + auto-trigger
   - `signals.py` — Signal weight calculations (8 types, including PASSIVE)
   - `quality.py` — Episode quality scoring (0-7 scale, warns on low quality)
   - `hooks.py` — Claude Code hook configuration for auto-recall on session start
   - `git_observer.py` — Passive git state observation at session boundaries
   - `protocol.py` — Minimal protocol text and CLAUDE.md generator
-  - `user_model.py` — Topic familiarity tracking
-  - `retrieval.py` — Full recall pipeline with application tracking
   - `starter_pack_loader.py` — YAML starter pack loader
   - `forgetting.py` — Ebbinghaus decay, spaced repetition, active pruning
   - `analogy.py` — Structural fingerprinting, combined semantic+structural search
@@ -109,15 +114,20 @@ cd frontend && npm run build                # production build to frontend/dist/
 ## Architecture
 
 Three-layer memory system:
-1. **Episodic** (Layer 1) — Raw session events stored in SQLite + ChromaDB
+1. **Episodic** (Layer 1) — Raw session events stored in SQLite/PostgreSQL + ChromaDB
 2. **Semantic** (Layer 2) — Consolidated theories with confidence scores
-3. **Working** (Layer 3) — Context-aware recall with winner-take-all activation
+3. **Working** (Layer 3) — Context-aware recall via RetrievalPipeline with user familiarity filtering
 
-Data flows: record -> episodes -> auto-consolidation -> theories -> recall -> graph-sync -> Neo4j -> frontend visualization
+Data flows: record -> episodes -> auto-consolidation -> theories -> forgetting pass -> recall -> graph-sync -> Neo4j -> frontend visualization
+
+### Database Backends
+
+- **SQLite** (default) — WAL mode, thread-safe, zero setup
+- **PostgreSQL** (optional) — Connection pooling, JSONB columns. Set `NEUROSYNC_DB_BACKEND=postgresql` and `NEUROSYNC_PG_DSN` to switch.
 
 ### Degraded Mode
 
-SQLite is the source of truth; ChromaDB is an acceleration layer. If ChromaDB is unavailable (corrupted HNSW index, permission error, missing dependency), NeuroSync runs in **degraded mode**:
+The primary database (SQLite or PostgreSQL) is the source of truth; ChromaDB is an acceleration layer. If ChromaDB is unavailable (corrupted HNSW index, permission error, missing dependency), NeuroSync runs in **degraded mode**:
 - Recording episodes and theories still works (SQLite writes always succeed)
 - Vector search (semantic recall, analogy, duplicate detection) returns empty results
 - The MCP server logs a warning at startup and continues operating

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ source .venv/bin/activate    # On Windows: .venv\Scripts\activate
 # 4. Install in dev mode
 pip install -e ".[dev]"
 
+# Optional: install with all backends
+pip install -e ".[dev,neo4j,postgresql]"
+
 # 5. Verify everything works
 pytest --cov=neurosync -v
 ruff check neurosync/
@@ -143,7 +146,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/) format:
 
 ### Scopes (optional)
 
-Use the module name: `db`, `vectorstore`, `mcp`, `cli`, `episodic`, `semantic`, `working`, `consolidation`, `config`, `protocol`, `signals`, `quality`, `retrieval`, `graph`, `frontend`.
+Use the module name: `db`, `pg_db`, `vectorstore`, `mcp`, `cli`, `episodic`, `semantic`, `working`, `retrieval`, `user_model`, `consolidation`, `forgetting`, `analogy`, `failure`, `hierarchy`, `causal`, `config`, `protocol`, `signals`, `quality`, `graph`, `frontend`.
 
 ### Examples
 
@@ -316,35 +319,45 @@ tests/test_<feature>.py        # e.g., tests/test_hardening.py
 Read `docs/architecture.md` for the full design. Quick summary:
 
 ```
-record -> episodes (SQLite + ChromaDB)
-       -> auto-consolidation
-       -> theories (SQLite + ChromaDB)
-       -> recall (winner-take-all)
+record -> episodes (SQLite/PostgreSQL + ChromaDB)
+       -> auto-consolidation (TF-IDF + causal merge)
+       -> theories (SQLite/PostgreSQL + ChromaDB)
+       -> forgetting pass (Ebbinghaus decay)
+       -> recall (RetrievalPipeline with winner-take-all + UserModel)
+       -> graph-sync -> Neo4j -> frontend visualization (optional)
 ```
 
-**Key principle:** SQLite is the source of truth. ChromaDB is an acceleration layer. Everything must work (in degraded mode) without ChromaDB.
+**Key principle:** The primary database (SQLite or PostgreSQL) is the source of truth. ChromaDB is an acceleration layer. Everything must work (in degraded mode) without ChromaDB.
 
 ### Module map
 
 | Module | Layer | Responsibility |
 |--------|-------|---------------|
-| `db.py` | Storage | SQLite CRUD, migrations, JSON handling |
+| `db.py` | Storage | SQLite CRUD, migrations, JSON handling (default backend) |
+| `pg_db.py` | Storage | PostgreSQL CRUD, connection pooling, JSONB (optional backend) |
 | `vectorstore.py` | Storage | ChromaDB wrapper, safe search |
-| `episodic.py` | Layer 1 | Session/episode lifecycle |
-| `semantic.py` | Layer 2 | Theory CRUD, confidence |
+| `episodic.py` | Layer 1 | Session/episode lifecycle, signal computation |
+| `semantic.py` | Layer 2 | Theory CRUD, confidence, linking |
 | `working.py` | Layer 3 | Recall with winner-take-all |
-| `consolidation.py` | Engine | Cluster + extract + MDL prune |
+| `retrieval.py` | Layer 3 | Full recall pipeline with familiarity filtering |
+| `user_model.py` | Layer 3 | Topic familiarity tracking, meta-learning |
+| `consolidation.py` | Engine | Cluster + TF-IDF extract + causal merge + MDL prune |
+| `forgetting.py` | Engine | Ebbinghaus decay, spaced repetition, active pruning |
+| `analogy.py` | Engine | Structural fingerprinting, semantic+structural search |
+| `failure.py` | Engine | Failure records, proactive warnings, anti-patterns |
+| `hierarchy.py` | Engine | Theory hierarchy traversal, semantic parents, merging |
+| `causal.py` | Engine | Causal graph construction, querying, semantic fallback |
 | `mcp_server.py` | Interface | MCP JSON-RPC tool handlers |
 | `cli.py` | Interface | CLI commands |
-| `signals.py` | Scoring | Episode weight calculation |
-| `quality.py` | Scoring | Episode quality scoring |
+| `signals.py` | Scoring | Episode weight calculation (7 active + 1 unwired) |
+| `quality.py` | Scoring | Episode quality scoring (0-7 scale) |
 | `graph.py` | Storage | Neo4j knowledge graph sync & querying |
 | `frontend/` | Visualization | React + TypeScript interactive graph viewer |
 
 ## What Not to Do
 
 - **Don't add MCP tools without discussion.** The tool count is deliberate. Propose new capabilities as extensions to existing tools first.
-- **Don't add external dependencies** without opening an issue. NeuroSync intentionally has minimal deps (chromadb, pyyaml).
+- **Don't add external dependencies** without opening an issue. NeuroSync intentionally has minimal core deps (chromadb, pyyaml). Optional deps (neo4j, psycopg2-binary) live in `[project.optional-dependencies]`.
 - **Don't break Python 3.9 compatibility.** No walrus operators in required paths, no `X | None` union syntax.
 - **Don't skip tests.** Every behavioral change needs a test.
 - **Don't force-push to shared branches.** Rebase locally before pushing, but don't rewrite shared history.

--- a/README.md
+++ b/README.md
@@ -464,6 +464,36 @@ Create `~/.neurosync/config.json` for fine-tuning:
 
 ---
 
+## PostgreSQL Backend (Optional)
+
+By default, NeuroSync uses SQLite — zero setup, perfect for single-developer use. For production deployments or when you want a more robust database, you can switch to PostgreSQL.
+
+### Install the PostgreSQL driver
+
+```bash
+pip install neurosync[postgresql]
+```
+
+### Start PostgreSQL (if not running)
+
+```bash
+docker run -d --name neurosync-pg -p 5432:5432 \
+  -e POSTGRES_DB=neurosync -e POSTGRES_PASSWORD=neurosync postgres:16
+```
+
+### Configure NeuroSync to use PostgreSQL
+
+```bash
+export NEUROSYNC_DB_BACKEND="postgresql"
+export NEUROSYNC_PG_DSN="postgresql://postgres:neurosync@localhost:5432/neurosync"
+```
+
+NeuroSync automatically creates all tables on first connection. If PostgreSQL is unreachable, it falls back to SQLite.
+
+> **Security note:** The PostgreSQL connection string (`NEUROSYNC_PG_DSN`) is only read from environment variables, never from `config.json`. This prevents accidental commits of credentials.
+
+---
+
 ## Neo4j Knowledge Graph (Optional)
 
 NeuroSync can sync its memory to a Neo4j graph database, letting you visualize episodes, theories, causal chains, and their connections as an interactive knowledge graph — like neurons connected to ideas, events, and patterns.
@@ -657,25 +687,31 @@ neurosync/
 ├── neurosync/                  # The main Python package
 │   ├── mcp_server.py           # The MCP server (talks JSON-RPC over stdio, 10 tools)
 │   ├── cli.py                  # Command-line interface
-│   ├── config.py               # Settings management
+│   ├── config.py               # Settings management (env > config.json > defaults)
 │   ├── models.py               # Data structures (Session, Episode, Theory, etc.)
-│   ├── db.py                   # SQLite database operations (with schema migrations)
+│   ├── db.py                   # SQLite database (WAL mode, migrations) — default backend
+│   ├── pg_db.py                # PostgreSQL database (connection pooling, JSONB) — optional backend
 │   ├── vectorstore.py          # ChromaDB for semantic search
-│   ├── episodic.py             # Layer 1: session & episode management
+│   ├── episodic.py             # Layer 1: session & episode management, signal computation
 │   ├── semantic.py             # Layer 2: theory management, confidence & linking
 │   ├── working.py              # Layer 3: recall & winner-take-all
-│   ├── consolidation.py        # Consolidation engine (causal extraction + auto-trigger)
-│   ├── signals.py              # Signal weight calculations (8 types)
-│   ├── quality.py              # Episode quality scoring
+│   ├── retrieval.py            # Full recall pipeline with familiarity filtering & parent context
+│   ├── user_model.py           # Topic familiarity tracking & meta-learning
+│   ├── consolidation.py        # Consolidation engine (TF-IDF + causal merge + auto-trigger)
+│   ├── signals.py              # Signal weight calculations (7 active + 1 unwired)
+│   ├── quality.py              # Episode quality scoring (0-7 scale)
+│   ├── forgetting.py           # Ebbinghaus decay, spaced repetition, active pruning
+│   ├── analogy.py              # Structural fingerprinting, semantic+structural search
+│   ├── failure.py              # Failure records, proactive warnings, anti-patterns
+│   ├── hierarchy.py            # Theory hierarchy traversal, semantic parents, merging
+│   ├── causal.py               # Causal graph construction, querying, semantic fallback
 │   ├── hooks.py                # Claude Code auto-recall hook generation
 │   ├── git_observer.py         # Passive git state observation
 │   ├── protocol.py             # Minimal protocol text & CLAUDE.md generator
-│   ├── user_model.py           # Tracks what you already know
-│   ├── retrieval.py            # Full recall pipeline
 │   ├── starter_pack_loader.py  # Loads YAML starter packs
 │   ├── graph.py                # Optional Neo4j knowledge graph sync & querying
 │   └── starter_packs/          # Built-in theory packs (YAML files)
-├── tests/                      # Test suite (~368 tests, 88%+ coverage)
+├── tests/                      # Test suite (~368 tests, 86%+ coverage)
 ├── frontend/                   # Interactive graph visualization (React + TypeScript)
 │   ├── src/
 │   │   ├── components/         # GraphCanvas, Sidebar, DetailPanel, QueryRunner, ConnectionForm
@@ -697,13 +733,13 @@ neurosync/
 | Component | Technology | Why |
 |---|---|---|
 | Language | Python 3.9+ | Widely available, good ecosystem |
-| Structured storage | SQLite (WAL mode) | Zero setup, fast, thread-safe |
+| Structured storage | SQLite (WAL mode, default) or PostgreSQL (optional) | Zero setup default, production-grade optional |
 | Semantic search | ChromaDB | Local vector DB, cosine similarity |
 | Knowledge graph | Neo4j (optional) | Visualize memory as a connected graph |
 | Graph frontend | React 18 + react-force-graph-2d | Interactive cosmological graph visualization |
 | Transport | MCP JSON-RPC 2.0 over stdio | Standard protocol for AI tool integration |
 | Build | hatchling | Modern Python packaging |
-| Testing | pytest + pytest-cov | ~368 tests, 88%+ coverage |
+| Testing | pytest + pytest-cov | ~368 tests, 86%+ coverage |
 | Linting | ruff | Fast, comprehensive |
 
 ---
@@ -738,8 +774,10 @@ git clone <repo>
 cd neurosync
 pip install -e ".[dev]"
 
-# Optional: install with Neo4j support
-pip install -e ".[dev,neo4j]"
+# Optional extras:
+pip install -e ".[dev,neo4j]"          # With Neo4j knowledge graph support
+pip install -e ".[dev,postgresql]"      # With PostgreSQL backend support
+pip install -e ".[dev,neo4j,postgresql]" # All optional features
 ```
 
 ### Run tests
@@ -814,7 +852,7 @@ pip install build twine
 
 ```bash
 # 1. Update the version number
-#    Edit neurosync/version.py → change __version__ = "0.4.0" (or whatever)
+#    Edit neurosync/version.py → change __version__ = "0.5.0" (or whatever)
 
 # 2. Build the package (creates dist/ folder with .tar.gz and .whl files)
 python -m build
@@ -856,7 +894,7 @@ pip install --index-url https://test.pypi.org/simple/ neurosync
 - [ ] Check: `twine check dist/*`
 - [ ] Upload: `twine upload dist/*`
 - [ ] Verify: `pip install neurosync` in a fresh virtualenv
-- [ ] Tag the release: `git tag v0.4.0 && git push --tags`
+- [ ] Tag the release: `git tag v0.5.0 && git push --tags`
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,19 +6,19 @@ NeuroSync models developer memory using three layers inspired by human neuroscie
 
 ### Layer 1: Episodic Memory
 - **What**: Raw events from coding sessions
-- **Storage**: SQLite `episodes` table + ChromaDB `neurosync_episodes` collection
+- **Storage**: SQLite/PostgreSQL `episodes` table + ChromaDB `neurosync_episodes` collection
 - **Lifecycle**: Created during sessions → consolidated into theories → decayed from vector store
 - **Event types**: decision, discovery, correction, pattern, frustration, question, file_change, architecture, debugging, explicit
 
 ### Layer 2: Semantic Memory
 - **What**: Consolidated patterns and theories extracted from episodes
-- **Storage**: SQLite `theories` table + ChromaDB `neurosync_theories` collection
+- **Storage**: SQLite/PostgreSQL `theories` table + ChromaDB `neurosync_theories` collection
 - **Lifecycle**: Created by consolidation → confirmed/contradicted → confidence decayed → retired
 - **Scopes**: project (single project), domain (shared domain), craft (general practice)
 
 ### Layer 3: Working Memory
 - **What**: Context-aware recall assembled from theories and recent episodes
-- **Algorithm**: Winner-take-all activation with user knowledge filtering
+- **Algorithm**: Winner-take-all activation via RetrievalPipeline with UserModel familiarity filtering
 - **Output**: Primary theory + 2-3 supporting theories + recent episodes, within token budget
 
 ## Data Flow
@@ -43,18 +43,25 @@ SQLite data is synced to Neo4j on demand via `neurosync graph-sync`. Neo4j provi
 
 A standalone React + TypeScript web app (`frontend/`) connects directly to Neo4j via Bolt WebSocket and renders the knowledge graph using `react-force-graph-2d`. Features multi-layer parallax star field, space-time fabric curvature near massive nodes, mass-weighted gravitational physics, Louvain community detection for cluster view, progressive loading, and 12 pre-built Cypher queries.
 
+## Database Backends
+
+- **SQLite** (default) — WAL mode, thread-safe, zero setup. Source of truth for all data.
+- **PostgreSQL** (optional) — Connection pooling via psycopg2, JSONB columns. Set `NEUROSYNC_DB_BACKEND=postgresql` and `NEUROSYNC_PG_DSN` to switch. Falls back to SQLite if unavailable.
+
 ## Signal Weighting
 
-Episodes are weighted by importance signals:
+Episodes are weighted by importance signals (7 active, 1 defined but unwired):
 
-| Signal | Formula | Purpose |
-|--------|---------|---------|
-| CORRECTION | 2^N | Mistakes accumulate exponentially |
-| DEPTH | N layers | Cross-cutting changes matter more |
-| SURPRISE | x3 | Contradictions to existing theories |
-| REPETITION | x5 | Things re-explained from past sessions |
-| DURATION | ratio | Time proportion on topic |
-| EXPLICIT | x10 | User explicitly flagged importance |
+| Signal | Formula | Purpose | Status |
+|--------|---------|---------|--------|
+| CORRECTION | 2^N | Mistakes accumulate exponentially | Active |
+| DEPTH | N layers | Cross-cutting changes matter more | Active |
+| SURPRISE | x3 | Contradictions to existing theories | Active |
+| REPETITION | x5 | Things re-explained from past sessions | Active |
+| EXPLICIT | x10 | User explicitly flagged importance | Active |
+| INTUITION | importance x 0.4 | Agent rates episode importance 1-5 | Active |
+| PASSIVE | x0.3 | Auto-observed events (git changes) | Active |
+| DURATION | ratio x 2.0 | Time proportion spent on topic | Defined, unwired |
 
 Composite weight = product of all multipliers, capped at 1000.
 
@@ -62,19 +69,25 @@ Composite weight = product of all multipliers, capped at 1000.
 
 1. Gather unconsolidated episodes (min 5)
 2. Cluster by ChromaDB cosine similarity (<0.8 threshold)
-3. Extract candidate theory from each cluster (2+ episodes)
-4. MDL prune: reject high description_length/coverage ratio
+3. Extract candidate theory from each cluster (2+ episodes) using 3 strategies:
+   - **Causal merge** — if cluster has episodes with cause/effect fields, merge into "When X, then Y" rule
+   - **TF-IDF keyword extraction** — for clusters of 3+, extract shared vocabulary and pick representative episode
+   - **Fallback** — use highest-weight episode as theory (truncated)
+4. MDL prune: reject candidates where theory length > 70% of combined cluster content
 5. Contradiction check against existing theories
 6. Merge (confirm existing) or create new theory
 7. Classify scope: project → domain → craft
 8. Decay old episodes from ChromaDB
-9. Apply confidence decay on stale theories
+9. Run ForgettingEngine pass: Ebbinghaus retention curves prune low-value episodes and decay stale theories
 
-## Winner-Take-All Recall
+## Winner-Take-All Recall (via RetrievalPipeline)
 
 1. Build context embedding from project + branch + user context
 2. Query theory collection (top 10)
 3. Score: `confidence / (1 + cosine_distance)`
 4. Pick highest as primary, next 2-3 as supporting
-5. Filter by user knowledge model (suppress familiar topics)
-6. Add recent episodes within token budget
+5. Filter by UserModel familiarity (suppress topics with familiarity > 0.9)
+6. Include parent context for theories in a hierarchy
+7. Check for continuation episodes from prior sessions
+8. Add recent episodes within token budget
+9. Track application of recalled theories for outcome-based confidence adjustment

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -6,25 +6,41 @@
 neurosync_record({events, session_summary})
   → Create/reuse Session
   → For each event:
-    → Create Episode (SQLite)
-    → Compute signal weight
+    → Create Episode (SQLite/PostgreSQL)
+    → Compute signal weights via compute_episode_signals():
+      - CORRECTION (if correction_count > 0)
+      - DEPTH (from layers_touched)
+      - SURPRISE (if contradicts existing theory)
+      - REPETITION (if times_explained > 1 via UserModel)
+      - EXPLICIT (if event_type == "explicit")
+      - INTUITION (if importance > 0)
+      - PASSIVE (if event_type == "observed")
+    → Save individual Signal records for audit trail
     → Embed in ChromaDB
   → For explicit_remember items:
     → Create Episode with EXPLICIT signal (weight x10)
+  → Capture git delta → PASSIVE observed episodes (weight x0.3)
+  → If corrections occurred: apply outcome-based confidence adjustment
+    (only to theories whose content overlaps with correction topics)
 ```
 
 ## Recall (Session Start)
 
 ```
 neurosync_recall({project, branch, context})
-  → Build query embedding
-  → Search theories (ChromaDB, top 10)
-  → Score: confidence / (1 + distance)
-  → Winner-take-all: pick highest
-  → Filter by user familiarity (suppress >0.9)
-  → Add 2-3 supporting theories
-  → Add recent episodes from same project
-  → Format within token budget (default 500)
+  → RetrievalPipeline.recall():
+    → Build query embedding
+    → Search theories (ChromaDB, top 10)
+    → Score: confidence / (1 + distance)
+    → Winner-take-all: pick highest
+    → Filter by UserModel familiarity (suppress >0.9)
+    → Include parent context for hierarchical theories
+    → Add 2-3 supporting theories
+    → Check for continuation episodes from prior sessions
+    → Add recent episodes from same project
+    → Format within token budget (default 500)
+  → Track user exposure via UserModel
+  → Refresh recalled theory retention via ForgettingEngine
 ```
 
 ## Correction
@@ -41,14 +57,19 @@ neurosync_correct({wrong, right, theory_id?})
 ```
 neurosync_consolidate({project?, dry_run?})
   → Gather unconsolidated episodes
-  → Cluster by semantic similarity
+  → Cluster by semantic similarity (ChromaDB cosine <0.8)
   → For each cluster (2+ episodes):
-    → Extract candidate theory
-    → MDL prune
+    → Extract candidate theory (3 strategies):
+      1. Causal merge: if episodes have cause/effect → "When X, then Y" rule
+      2. TF-IDF keywords: for 3+ episodes → keyword extraction + representative episode
+      3. Fallback: highest-weight episode content (truncated)
+    → MDL prune: reject if theory length > 70% of cluster content
     → Check for existing matching theory
-    → Confirm or create theory
+    → Confirm or create theory (initial confidence 0.5)
   → Mark episodes as consolidated
-  → Apply confidence decay on stale theories
+  → Run ForgettingEngine pass:
+    → Ebbinghaus retention curves prune low-retention episodes
+    → Decay stale theories without recent confirmation
 ```
 
 ## Confidence Lifecycle
@@ -57,7 +78,9 @@ neurosync_consolidate({project?, dry_run?})
 Theory created → confidence 0.5
   → Confirmed by consolidation → +0.1 * (1 - current) asymptotic
   → Contradicted → -0.15
-  → No confirmation for 30+ days → -0.01/day
+  → Session corrections on related topics → outcome-based penalty (max -0.1)
+  → Recalled and applied → retention refreshed via ForgettingEngine
+  → Ebbinghaus decay: R = e^(-t/S) where S = base × weight × quality × 2^reinforcements
   → Confidence ≤ 0.05 → auto-retired
   → Manually retired → active = false
 ```

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2,7 +2,7 @@
 
 ## neurosync_recall
 
-Retrieve relevant context at session start.
+Retrieve relevant context at session start. Uses RetrievalPipeline with winner-take-all scoring and UserModel familiarity filtering.
 
 **Parameters:**
 - `project` (string, optional) — Auto-detected from git if omitted
@@ -10,20 +10,20 @@ Retrieve relevant context at session start.
 - `context` (string, optional) — Additional context for retrieval
 - `max_tokens` (integer, default: 500) — Maximum output tokens
 
-**Returns:** Primary theory, supporting theories, recent episodes, tokens used.
+**Returns:** Primary theory, supporting theories, recent episodes, continuation (if any), tokens used.
 
 ## neurosync_record
 
-Record session episodes at session end.
+Record session episodes at session end. Computes all applicable signal types for each event.
 
 **Parameters:**
-- `events` (array, required) — Events to record. Each: `{type, content, files?, layers?}`
+- `events` (array, required) — Events to record. Each: `{type, content, cause?, effect?, reasoning?, files?, layers?, importance?}`
 - `session_summary` (string, optional) — Summary of the session
 - `project` (string, optional)
 - `branch` (string, optional)
-- `explicit_remember` (array of strings, optional) — High-weight memories
+- `explicit_remember` (array of strings, optional) — High-weight memories (10x)
 
-**Event types:** decision, discovery, correction, pattern, frustration, question, file_change, architecture, debugging, explicit
+**Event types:** decision, discovery, correction, pattern, frustration, question, file_change, architecture, debugging, explicit, causal, observed
 
 ## neurosync_remember
 
@@ -32,47 +32,81 @@ Explicitly remember something with high signal weight (x10).
 **Parameters:**
 - `content` (string, required) — What to remember
 - `type` (string, default: "explicit") — Event type
+- `importance` (integer, optional, 1-5) — INTUITION signal weight
+- `reasoning` (string, optional) — Why this is worth remembering
+- `cause` (string, optional) — What triggered this memory
+- `effect` (string, optional) — What resulted
 
 ## neurosync_query
 
-Semantic search across episodes and/or theories.
+Search across episodes, theories, analogies, causal graph, or failures.
 
 **Parameters:**
 - `query` (string, required) — Search query
+- `mode` (string, default: "semantic") — Search mode: `semantic`, `analogy`, `causal`, `failures`
 - `scope` (string, default: "all") — "all", "episodes", or "theories"
 - `project` (string, optional)
 - `limit` (integer, default: 10)
 
 ## neurosync_correct
 
-Record an AI mistake with exponential weight.
+Record an AI mistake with exponential weight (2^N where N = correction count in session).
 
 **Parameters:**
 - `wrong` (string, required) — What was wrong
 - `right` (string, required) — What is correct
-- `theory_id` (string, optional) — Theory to contradict
+- `theory_id` (string, optional) — Theory to contradict (reduces confidence by 0.15)
+
+## neurosync_handoff
+
+Record a cross-session handoff for multi-session tasks. Creates a high-weight continuation episode.
+
+**Parameters:**
+- `goal` (string, required) — Overall goal of the task
+- `accomplished` (string, required) — What was accomplished this session
+- `remaining` (string, required) — What still needs to be done
+- `next_step` (string, required) — Concrete next step for the next session
+- `blockers` (string, optional) — Any blockers or open questions
 
 ## neurosync_status
 
 Health check — no parameters.
 
-**Returns:** Episode, theory, contradiction counts; ChromaDB sizes; current session info.
+**Returns:** Episode, theory, contradiction counts; ChromaDB sizes; current session info; graph health (if Neo4j configured).
 
 ## neurosync_theories
 
-Browse, inspect, or retire theories.
+Browse, inspect, retire, relate, or view hierarchy of theories.
 
 **Parameters:**
-- `action` (string, default: "list") — "list", "detail", or "retire"
+- `action` (string, default: "list") — "list", "detail", "retire", "relate", "graph"
 - `scope` (string, optional) — "project", "domain", or "craft"
 - `project` (string, optional)
 - `theory_id` (string, optional) — Required for detail/retire
+- `related_ids` (array of strings, optional) — Theory IDs to link (for relate action)
 - `limit` (integer, default: 20)
 
 ## neurosync_consolidate
 
-Trigger consolidation engine.
+Trigger consolidation engine. Runs clustering, theory extraction (TF-IDF + causal merge), MDL pruning, and ForgettingEngine pass.
 
 **Parameters:**
 - `project` (string, optional) — Limit to project
 - `dry_run` (boolean, default: false) — Preview only
+
+## neurosync_graph
+
+Query or sync the Neo4j knowledge graph. Requires `pip install neurosync[neo4j]`.
+
+**Parameters:**
+- `action` (string, required) — "status", "sync", "prebuilt", "query"
+- `cypher` (string, optional) — Read-only Cypher query (for "query" action)
+- `parameters` (object, optional) — Parameters for Cypher query
+- `prebuilt_name` (string, optional) — Name of pre-built query (for "prebuilt" action)
+- `project` (string, optional) — Project filter for sync
+
+**Actions:**
+- `status` — Graph health check (node/relationship counts)
+- `sync` — Sync SQLite data to Neo4j (MERGE-based, idempotent)
+- `prebuilt` — List or run pre-built queries (12 available)
+- `query` — Run a read-only Cypher query (write operations are blocked)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -66,6 +66,8 @@ Environment variables:
 - `NEUROSYNC_DATA_DIR` — Data directory (default: `~/.neurosync`)
 - `NEUROSYNC_DEFAULT_PROJECT` — Default project name
 - `NEUROSYNC_DEFAULT_BRANCH` — Default branch name
+- `NEUROSYNC_DB_BACKEND` — Database backend: `sqlite` (default) or `postgresql`
+- `NEUROSYNC_PG_DSN` — PostgreSQL connection string (when using postgresql backend)
 
 Config file (`~/.neurosync/config.json`):
 ```json
@@ -78,6 +80,24 @@ Config file (`~/.neurosync/config.json`):
   "max_signal_weight": 1000.0
 }
 ```
+
+## PostgreSQL Backend (Optional)
+
+By default, NeuroSync uses SQLite. To switch to PostgreSQL:
+
+```bash
+# Install the PostgreSQL driver
+pip install neurosync[postgresql]
+
+# Start PostgreSQL (if not running)
+docker run -d --name neurosync-pg -p 5432:5432 -e POSTGRES_DB=neurosync -e POSTGRES_PASSWORD=neurosync postgres:16
+
+# Configure NeuroSync to use PostgreSQL
+export NEUROSYNC_DB_BACKEND="postgresql"
+export NEUROSYNC_PG_DSN="postgresql://postgres:neurosync@localhost:5432/neurosync"
+```
+
+NeuroSync automatically creates all tables on first connection. If PostgreSQL is unreachable, it falls back to SQLite.
 
 ## Neo4j Knowledge Graph (Optional)
 

--- a/docs/skill-setup.md
+++ b/docs/skill-setup.md
@@ -82,6 +82,8 @@ You should see it autocomplete. Press Enter with no arguments to see the help me
 /neurosync remember <text> — Store an important fact
 /neurosync query <text>  — Search memories (prefix: failures: causal: analogy:)
 /neurosync theories      — Browse all learned patterns
+/neurosync graph-sync    — Sync memory to Neo4j knowledge graph
+/neurosync graph-status  — Check Neo4j graph health and counts
 /neurosync reset         — Clear all memory data (dangerous)
 ```
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,6 +57,9 @@ export default function App() {
         onToggleType={graph.toggleType}
         searchQuery={graph.searchQuery}
         onSearchChange={graph.setSearchQuery}
+        projects={graph.projects}
+        projectFilter={graph.projectFilter}
+        onProjectChange={graph.setProjectFilter}
         onRunPrebuilt={graph.runPrebuilt}
         onRunCustom={graph.runCustomQuery}
         onLoadOverview={graph.loadOverview}

--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -212,19 +212,63 @@ export default function GraphCanvas({ graphData, selectedNode, onNodeClick, onBa
   const [zoomLevel, setZoomLevel] = useState(1);
   const prevResetCountRef = useRef(viewResetCount);
   const timeRef = useRef(0);
+  const idleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const animatingRef = useRef(true);
 
-  // ── Animation tick (for star twinkle, breathing) ──
+  // ── Idle-aware animation tick (pauses after 5s of no interaction) ──
   useEffect(() => {
     let running = true;
     let last = performance.now();
+    let rafId = 0;
+
     const tick = (now: number) => {
       if (!running) return;
-      timeRef.current += (now - last) * 0.001; // seconds
+      timeRef.current += (now - last) * 0.001;
       last = now;
-      requestAnimationFrame(tick);
+      if (animatingRef.current) {
+        rafId = requestAnimationFrame(tick);
+      }
     };
-    requestAnimationFrame(tick);
-    return () => { running = false; };
+
+    const startAnimating = () => {
+      if (!animatingRef.current) {
+        animatingRef.current = true;
+        last = performance.now();
+        rafId = requestAnimationFrame(tick);
+      }
+      // Reset idle timer
+      if (idleTimeoutRef.current) clearTimeout(idleTimeoutRef.current);
+      idleTimeoutRef.current = setTimeout(() => {
+        animatingRef.current = false;
+      }, 5000); // Pause animation after 5s idle
+    };
+
+    // Start initial animation
+    startAnimating();
+    rafId = requestAnimationFrame(tick);
+
+    // Wake on user interaction
+    const el = containerRef.current;
+    const wake = () => startAnimating();
+    if (el) {
+      el.addEventListener('mousemove', wake, { passive: true });
+      el.addEventListener('mousedown', wake, { passive: true });
+      el.addEventListener('wheel', wake, { passive: true });
+      el.addEventListener('touchstart', wake, { passive: true });
+    }
+
+    return () => {
+      running = false;
+      animatingRef.current = false;
+      cancelAnimationFrame(rafId);
+      if (idleTimeoutRef.current) clearTimeout(idleTimeoutRef.current);
+      if (el) {
+        el.removeEventListener('mousemove', wake);
+        el.removeEventListener('mousedown', wake);
+        el.removeEventListener('wheel', wake);
+        el.removeEventListener('touchstart', wake);
+      }
+    };
   }, []);
 
   // ── Container resize tracking ──
@@ -238,6 +282,15 @@ export default function GraphCanvas({ graphData, selectedNode, onNodeClick, onBa
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
+
+  // ── Wake animation when graph data changes ──
+  useEffect(() => {
+    if (graphData.nodes.length > 0) {
+      animatingRef.current = true;
+      if (idleTimeoutRef.current) clearTimeout(idleTimeoutRef.current);
+      idleTimeoutRef.current = setTimeout(() => { animatingRef.current = false; }, 5000);
+    }
+  }, [graphData]);
 
   // ── Configure gravitational forces (once on mount) ──
   const forcesConfigured = useRef(false);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -21,6 +21,9 @@ interface Props {
   onToggleType: (type: NodeType) => void;
   searchQuery: string;
   onSearchChange: (query: string) => void;
+  projects: string[];
+  projectFilter: string;
+  onProjectChange: (project: string) => void;
   onRunPrebuilt: (cypher: string, params?: Record<string, unknown>) => void;
   onRunCustom: (cypher: string) => void;
   onLoadOverview: () => void;
@@ -33,6 +36,7 @@ export default function Sidebar({
   onConnect, onDisconnect,
   visibleTypes, onToggleType,
   searchQuery, onSearchChange,
+  projects, projectFilter, onProjectChange,
   onRunPrebuilt, onRunCustom,
   onLoadOverview,
   nodeCount, linkCount,
@@ -85,6 +89,23 @@ export default function Sidebar({
               className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 focus:border-blue-500 focus:outline-none"
             />
           </div>
+
+          {/* Project filter */}
+          {projects.length > 0 && (
+            <div className="border-b border-gray-800 pb-3">
+              <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">Project</h3>
+              <select
+                value={projectFilter}
+                onChange={e => onProjectChange(e.target.value)}
+                className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 focus:border-blue-500 focus:outline-none"
+              >
+                <option value="">All projects</option>
+                {projects.map(p => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {/* Node type filters */}
           <div className="border-b border-gray-800 pb-3">

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -112,11 +112,14 @@ RETURN t, r1, e, r2, s`,
   },
   {
     name: 'knowledge_graph_overview',
-    description: 'Full graph overview — all nodes and relationships',
-    cypher: `MATCH (n)
-OPTIONAL MATCH (n)-[r]->(m)
+    description: 'Full graph overview — all connected nodes',
+    cypher: `MATCH (n)-[r]->(m)
 RETURN n, r, m
-LIMIT 500`,
+LIMIT 1000
+UNION ALL
+MATCH (orphan) WHERE NOT (orphan)--()
+RETURN orphan AS n, null AS r, null AS m
+LIMIT 100`,
   },
   {
     name: 'episode_to_theory_lineage',

--- a/frontend/src/hooks/useGraphData.ts
+++ b/frontend/src/hooks/useGraphData.ts
@@ -91,6 +91,7 @@ export function useGraphData() {
     new Set(['Session', 'Episode', 'Theory', 'Concept', 'StructuralPattern', 'FailureRecord', 'Contradiction', 'UserKnowledge']),
   );
   const [searchQuery, setSearchQuery] = useState('');
+  const [projectFilter, setProjectFilter] = useState('');
   const fullDataRef = useRef<GraphData>({ nodes: [], links: [] });
   // Counter that increments on full data replacement (overview, prebuilt, custom) — NOT on expand
   const [viewResetCount, setViewResetCount] = useState(0);
@@ -163,11 +164,44 @@ export function useGraphData() {
     }
   }, [updateData]);
 
+  // Extract unique project names from Session nodes
+  const projects = useMemo((): string[] => {
+    const projectSet = new Set<string>();
+    for (const n of graphData.nodes) {
+      const p = (n.properties.project as string) ?? '';
+      if (p) projectSet.add(p);
+    }
+    return Array.from(projectSet).sort();
+  }, [graphData.nodes]);
+
   const filteredData = useMemo((): GraphData => {
     let nodes = graphData.nodes;
 
     // Filter by visible types
     nodes = nodes.filter(n => visibleTypes.has(n.label));
+
+    // Filter by project (Session nodes carry project; other nodes included if linked)
+    if (projectFilter) {
+      const projectSessionIds = new Set(
+        graphData.nodes
+          .filter(n => n.label === 'Session' && n.properties.project === projectFilter)
+          .map(n => n.id),
+      );
+      // Keep nodes that are: in the project, or linked to a session in the project
+      const linkedIds = new Set<string>();
+      for (const l of graphData.links) {
+        const src = typeof l.source === 'object' ? (l.source as GraphNode).id : l.source;
+        const tgt = typeof l.target === 'object' ? (l.target as GraphNode).id : l.target;
+        if (projectSessionIds.has(src)) linkedIds.add(tgt);
+        if (projectSessionIds.has(tgt)) linkedIds.add(src);
+      }
+      nodes = nodes.filter(n =>
+        projectSessionIds.has(n.id) ||
+        linkedIds.has(n.id) ||
+        (n.properties.project as string) === projectFilter ||
+        (n.properties.scope_qualifier as string) === projectFilter,
+      );
+    }
 
     // Filter by search query
     if (searchQuery) {
@@ -183,7 +217,7 @@ export function useGraphData() {
     });
 
     return { nodes, links };
-  }, [graphData, visibleTypes, searchQuery]);
+  }, [graphData, visibleTypes, searchQuery, projectFilter]);
 
   const toggleType = useCallback((type: NodeType) => {
     setVisibleTypes(prev => {
@@ -202,6 +236,9 @@ export function useGraphData() {
     visibleTypes,
     searchQuery,
     setSearchQuery,
+    projects,
+    projectFilter,
+    setProjectFilter,
     toggleType,
     loadOverview,
     expandNode,

--- a/neurosync/causal.py
+++ b/neurosync/causal.py
@@ -201,14 +201,76 @@ class CausalGraph:
     def get_causal_neighborhood(
         self, text: str, radius: int = 2, project: Optional[str] = None,
     ) -> dict[str, Any]:
-        """Get upstream causes + downstream effects + links around a concept."""
+        """Get upstream causes + downstream effects + links around a concept.
+
+        Uses exact text match first. If no results found and vectorstore
+        is available, falls back to semantic similarity search across
+        causal link texts to find approximate matches.
+        """
         upstream = self.get_causes_of(text, max_depth=radius, project=project)
         downstream = self.get_effects_of(text, max_depth=radius, project=project)
+
+        # Semantic fallback: if exact match found nothing, search by embedding
+        if not upstream and not downstream and self._vs:
+            semantic_links = self._semantic_causal_search(text, project=project)
+            if semantic_links:
+                # Re-run with discovered cause/effect texts
+                for link in semantic_links:
+                    upstream.extend(
+                        self.get_causes_of(link.effect_text, max_depth=1, project=project)
+                    )
+                    downstream.extend(
+                        self.get_effects_of(link.cause_text, max_depth=1, project=project)
+                    )
+                # Deduplicate by link id
+                seen_ids: set[Any] = set()
+                unique_upstream = []
+                for link in upstream:
+                    if link.id not in seen_ids:
+                        seen_ids.add(link.id)
+                        unique_upstream.append(link)
+                unique_downstream = []
+                for link in downstream:
+                    if link.id not in seen_ids:
+                        seen_ids.add(link.id)
+                        unique_downstream.append(link)
+                upstream = unique_upstream
+                downstream = unique_downstream
+
         return {
             "concept": text,
             "upstream": [self._link_summary(link) for link in upstream],
             "downstream": [self._link_summary(link) for link in downstream],
         }
+
+    def _semantic_causal_search(
+        self, query: str, project: Optional[str] = None, n_results: int = 5,
+    ) -> list[CausalLink]:
+        """Find causal links whose cause or effect text is semantically similar to query."""
+        if not self._vs:
+            return []
+        # Search episodes that have causal content
+        results = self._vs.search_episodes(query, n_results=n_results * 2)
+        found_links: list[CausalLink] = []
+        seen_ids: set[Any] = set()
+        for r in results:
+            ep_id = r.get("id", "")
+            if not ep_id:
+                continue
+            episode = self._db.get_episode(ep_id)
+            if not episode or not episode.cause or not episode.effect:
+                continue
+            # Find matching causal link
+            links = self._db.list_causal_links(
+                cause_text=episode.cause, effect_text=episode.effect, project=project,
+            )
+            for link in links:
+                if link.id not in seen_ids:
+                    seen_ids.add(link.id)
+                    found_links.append(link)
+                    if len(found_links) >= n_results:
+                        return found_links
+        return found_links
 
     # --- Analysis ---
 

--- a/neurosync/config.py
+++ b/neurosync/config.py
@@ -34,6 +34,10 @@ class NeuroSyncConfig:
     protocol_hints_enabled: bool = True
     auto_consolidation_enabled: bool = True
     auto_consolidation_threshold: int = 20
+    # Database backend: "sqlite" (default) or "postgresql"
+    db_backend: str = ""
+    # PostgreSQL connection string (only when db_backend="postgresql")
+    pg_dsn: str = ""
     neo4j_uri: str = ""
     neo4j_user: str = ""
     neo4j_password: str = ""
@@ -55,6 +59,13 @@ class NeuroSyncConfig:
             self.sqlite_path = os.path.join(self.data_dir, "neurosync.sqlite3")
         if not self.chroma_path:
             self.chroma_path = os.path.join(self.data_dir, "chroma")
+        if not self.db_backend:
+            self.db_backend = os.environ.get("NEUROSYNC_DB_BACKEND", "sqlite")
+        if not self.pg_dsn:
+            self.pg_dsn = os.environ.get(
+                "NEUROSYNC_PG_DSN",
+                "postgresql://localhost:5432/neurosync",
+            )
         if not self.neo4j_uri:
             self.neo4j_uri = os.environ.get("NEUROSYNC_NEO4J_URI", "bolt://localhost:7687")
         if not self.neo4j_user:
@@ -81,15 +92,16 @@ class NeuroSyncConfig:
             "NEUROSYNC_DATA_DIR",
             "NEUROSYNC_DEFAULT_PROJECT",
             "NEUROSYNC_DEFAULT_BRANCH",
+            "NEUROSYNC_DB_BACKEND",
         ):
             val = os.environ.get(env_key)
             if val:
                 field_name = env_key.replace("NEUROSYNC_", "").lower()
                 overrides[field_name] = val
-        # Never load neo4j_password from config.json — it must only come from
-        # the NEUROSYNC_NEO4J_PASSWORD environment variable (handled in __post_init__)
-        # to avoid storing secrets in plaintext on disk.
+        # Never load secrets from config.json — they must only come from
+        # environment variables (handled in __post_init__).
         overrides.pop("neo4j_password", None)
+        overrides.pop("pg_dsn", None)
         return cls(**{k: v for k, v in overrides.items() if k in cls.__dataclass_fields__})
 
     def ensure_dirs(self) -> None:

--- a/neurosync/consolidation.py
+++ b/neurosync/consolidation.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
+import math
+import re
+from collections import Counter, defaultdict
 from typing import Any, Optional
 
 from neurosync.analogy import AnalogyEngine
@@ -53,7 +55,7 @@ class ConsolidationEngine:
         semantic: SemanticMemory,
         min_episodes: int = 5,
         similarity_threshold: float = 0.8,
-        mdl_threshold: float = 5.0,
+        mdl_threshold: float = 0.7,
     ) -> None:
         self._db = db
         self._vs = vectorstore
@@ -149,10 +151,10 @@ class ConsolidationEngine:
             unique_ids = list(set(consolidated_ids))
             self._episodic.mark_consolidated(unique_ids)
 
-        # 8. Apply confidence decay
+        # 8. Confidence decay is handled by ForgettingEngine.run_forgetting_pass()
+        # which is called after consolidation in mcp_server._try_auto_consolidate().
+        # This avoids competing linear vs Ebbinghaus decay systems.
         decayed = 0
-        if not dry_run:
-            decayed = self._semantic.apply_confidence_decay()
 
         result: dict[str, Any] = {
             "episodes_processed": len(episodes),
@@ -223,30 +225,26 @@ class ConsolidationEngine:
     def _extract_candidate(self, cluster: list[Episode]) -> Optional[str]:
         """Extract a candidate theory from a cluster of episodes.
 
-        Strategy: if causal episodes exist, compose a causal theory.
-        Otherwise, pick the most concise episode content as the theory basis.
+        Uses multi-strategy extraction (all local, no LLM):
+        1. Causal episodes → merge causes/effects into generalized causal theory
+        2. Multi-episode → extract shared keywords via TF-IDF and compose summary
+        3. Fallback → highest-weight episode with type annotation
         """
         if not cluster:
             return None
 
-        # Separate causal vs non-causal episodes
+        # Strategy 1: Causal episodes — merge multiple causes/effects
         causal_eps = [ep for ep in cluster if ep.cause and ep.effect]
-
         if causal_eps:
-            # Compose causal theory from highest-weight causal episode
-            sorted_causal = sorted(
-                causal_eps,
-                key=lambda ep: (-ep.signal_weight, len(ep.content)),
-            )
-            best = sorted_causal[0]
-            reasoning = best.reasoning or ""
-            if reasoning:
-                content = f"When {best.cause}, then {best.effect} because {reasoning}"
-            else:
-                content = f"When {best.cause}, then {best.effect}"
-            return content
+            return self._extract_causal_theory(causal_eps)
 
-        # Fallback: use highest-weighted, most concise episode
+        # Strategy 2: Multi-episode keyword extraction and summary
+        if len(cluster) >= 3:
+            keyword_theory = self._extract_keyword_theory(cluster)
+            if keyword_theory:
+                return keyword_theory
+
+        # Strategy 3: Fallback — highest-weight, most concise episode
         sorted_eps = sorted(
             cluster,
             key=lambda ep: (-ep.signal_weight, len(ep.content)),
@@ -256,7 +254,7 @@ class ConsolidationEngine:
         if not content:
             return None
 
-        # If all episodes share a common event type, note it
+        # Annotate with shared event type if uniform
         types = {ep.event_type for ep in cluster}
         if len(types) == 1:
             common_type = types.pop()
@@ -264,6 +262,122 @@ class ConsolidationEngine:
                 content = f"[{common_type}] {content}"
 
         return content
+
+    def _extract_causal_theory(self, causal_eps: list[Episode]) -> str:
+        """Merge multiple causal episodes into a generalized theory.
+
+        If multiple episodes share similar causes, combine their effects.
+        Otherwise, use the highest-weight causal episode.
+        """
+        sorted_causal = sorted(
+            causal_eps,
+            key=lambda ep: (-ep.signal_weight, len(ep.content)),
+        )
+        best = sorted_causal[0]
+        reasoning = best.reasoning or ""
+
+        if len(causal_eps) >= 2:
+            # Collect all unique effects
+            effects = []
+            seen_effects: set[str] = set()
+            for ep in sorted_causal:
+                effect_lower = ep.effect.strip().lower()
+                if effect_lower not in seen_effects:
+                    seen_effects.add(effect_lower)
+                    effects.append(ep.effect.strip())
+
+            if len(effects) > 1:
+                # Multiple effects from similar cause — merge
+                effects_text = "; ".join(effects[:3])
+                if reasoning:
+                    return f"When {best.cause}, then {effects_text} because {reasoning}"
+                return f"When {best.cause}, then {effects_text}"
+
+        # Single causal pattern
+        if reasoning:
+            return f"When {best.cause}, then {best.effect} because {reasoning}"
+        return f"When {best.cause}, then {best.effect}"
+
+    def _extract_keyword_theory(self, cluster: list[Episode]) -> Optional[str]:
+        """Extract shared themes from cluster using TF-IDF-like keyword scoring.
+
+        Pure local computation — no LLM calls.
+        """
+        # Tokenize each episode's content
+        stop_words = frozenset({
+            "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+            "have", "has", "had", "do", "does", "did", "will", "would", "could",
+            "should", "may", "might", "shall", "can", "need", "to", "of", "in",
+            "for", "on", "with", "at", "by", "from", "as", "into", "through",
+            "during", "before", "after", "above", "below", "between", "and", "or",
+            "but", "if", "then", "else", "when", "while", "so", "that", "this",
+            "these", "those", "it", "its", "not", "no", "nor", "only", "own",
+            "same", "than", "too", "very", "just", "because", "about", "up",
+        })
+
+        def tokenize(text: str) -> list[str]:
+            words = re.findall(r'[a-zA-Z_][a-zA-Z0-9_]*', text.lower())
+            return [w for w in words if len(w) > 2 and w not in stop_words]
+
+        # Document frequency: how many episodes contain each word
+        doc_freq: Counter = Counter()
+        doc_tokens: list[list[str]] = []
+        for ep in cluster:
+            tokens = tokenize(ep.content)
+            doc_tokens.append(tokens)
+            unique_tokens = set(tokens)
+            for t in unique_tokens:
+                doc_freq[t] += 1
+
+        n_docs = len(cluster)
+        if n_docs < 2:
+            return None
+
+        # TF-IDF score: words that appear in multiple (but not all) documents are most informative
+        # Also weight by signal_weight of containing episodes
+        keyword_scores: Counter = Counter()
+        for i, tokens in enumerate(doc_tokens):
+            tf: Counter = Counter(tokens)
+            ep_weight = cluster[i].signal_weight
+            for word, count in tf.items():
+                df = doc_freq[word]
+                if df < 2:
+                    continue  # Must appear in at least 2 episodes
+                # IDF that peaks for words in ~half the documents
+                idf = math.log(n_docs / df) + 0.5
+                keyword_scores[word] += count * idf * min(ep_weight, 5.0)
+
+        top_keywords = [w for w, _ in keyword_scores.most_common(8)]
+        if len(top_keywords) < 2:
+            return None
+
+        # Find the most representative episode (highest overlap with top keywords)
+        best_ep = max(
+            cluster,
+            key=lambda ep: (
+                sum(1 for kw in top_keywords if kw in ep.content.lower()),
+                ep.signal_weight,
+            ),
+        )
+
+        # Compose theory: keywords as topic + representative content
+        theme = ", ".join(top_keywords[:5])
+        # Use shared event type if uniform
+        types = {ep.event_type for ep in cluster}
+        type_prefix = ""
+        if len(types) == 1:
+            t = types.pop()
+            if t != "decision":
+                type_prefix = f"[{t}] "
+
+        # Truncate representative content to be concise
+        rep_content = best_ep.content.strip()
+        if len(rep_content) > 200:
+            # Find sentence boundary near 200 chars
+            boundary = rep_content.rfind('. ', 100, 250)
+            rep_content = rep_content[:boundary + 1] if boundary > 0 else rep_content[:200] + "..."
+
+        return f"{type_prefix}{rep_content} (themes: {theme})"
 
     def _passes_mdl(self, candidate: str, cluster: list[Episode]) -> bool:
         """MDL pruning: reject if description_length / coverage is too high."""

--- a/neurosync/episodic.py
+++ b/neurosync/episodic.py
@@ -8,6 +8,7 @@ from neurosync.analogy import AnalogyEngine
 from neurosync.db import Database
 from neurosync.models import Episode, Session, Signal, _utcnow
 from neurosync.quality import score_episode_quality
+from neurosync.signals import compute_episode_signals
 from neurosync.vectorstore import VectorStore
 
 
@@ -58,10 +59,35 @@ class EpisodicMemory:
         effect: str = "",
         reasoning: str = "",
         importance: int = 0,
+        contradicts_theory: bool = False,
+        times_explained: int = 0,
+        correction_count: int = 0,
     ) -> Episode:
-        """Record a new episode within a session."""
-        # Importance (1-5 intuition rating) boosts signal weight
-        if importance and importance > 0:
+        """Record a new episode within a session.
+
+        Computes 7 active signal types via compute_episode_signals:
+        CORRECTION (correction_count > 0), DEPTH (layers_touched),
+        SURPRISE (contradicts_theory), REPETITION (times_explained),
+        EXPLICIT (event_type == "explicit"), INTUITION (importance),
+        PASSIVE (saved separately for observed events).
+        DURATION is defined but not yet wired (requires session-level timing).
+        """
+        layers = layers_touched or []
+        # Compute all applicable signals via the signals module
+        signals, composite = compute_episode_signals(
+            event_type=event_type,
+            layers_touched=layers,
+            correction_count=correction_count,
+            contradicts_theory=contradicts_theory,
+            times_explained=times_explained,
+            is_explicit=(event_type == "explicit"),
+            importance=importance,
+        )
+        # Apply composite signal weight (minimum of base weight or composite)
+        if signals:
+            signal_weight = max(signal_weight, composite)
+        elif importance and importance > 0:
+            # Fallback: simple importance boost if no signals computed
             signal_weight *= 1.0 + (importance * 0.5)
         episode = Episode(
             session_id=session_id,
@@ -69,7 +95,7 @@ class EpisodicMemory:
             content=content,
             context=context,
             files_touched=files_touched or [],
-            layers_touched=layers_touched or [],
+            layers_touched=layers,
             signal_weight=signal_weight,
             metadata=metadata or {},
             cause=cause,
@@ -83,6 +109,15 @@ class EpisodicMemory:
         if fp.patterns:
             episode.structural_fingerprint = fp.to_string()
         self._db.save_episode(episode)
+        # Save individual signal records for analysis
+        for sig in signals:
+            signal_record = Signal(
+                episode_id=episode.id,
+                signal_type=sig.signal_type,
+                raw_value=sig.raw_value,
+                multiplier=sig.multiplier,
+            )
+            self._db.save_signal(signal_record)
         # Write fingerprints to junction table
         if episode.structural_fingerprint:
             self._db.set_entity_fingerprints(episode.id, "episode", list(fp.patterns))
@@ -122,22 +157,22 @@ class EpisodicMemory:
         session_id: str,
         content: str,
         event_type: str = "explicit",
+        importance: int = 0,
+        cause: str = "",
+        effect: str = "",
+        reasoning: str = "",
     ) -> Episode:
         """Record an explicit 'remember this' episode with high signal weight."""
-        episode = self.record_episode(
+        return self.record_episode(
             session_id=session_id,
             event_type=event_type,
             content=content,
             signal_weight=10.0,
+            importance=importance,
+            cause=cause,
+            effect=effect,
+            reasoning=reasoning,
         )
-        signal = Signal(
-            episode_id=episode.id,
-            signal_type="EXPLICIT",
-            raw_value=1.0,
-            multiplier=10.0,
-        )
-        self._db.save_signal(signal)
-        return episode
 
     def record_correction(
         self,
@@ -146,23 +181,21 @@ class EpisodicMemory:
         right: str,
         correction_count: int = 1,
     ) -> Episode:
-        """Record a correction episode with exponential weight."""
+        """Record a correction episode with exponential weight.
+
+        Delegates fully to record_episode which handles CORRECTION signal
+        computation via compute_episode_signals. No manual signal creation
+        needed here.
+        """
         weight = min(2**correction_count, 1000.0)
         content = f"CORRECTION: Was told '{wrong}' but correct answer is '{right}'"
-        episode = self.record_episode(
+        return self.record_episode(
             session_id=session_id,
             event_type="correction",
             content=content,
             signal_weight=weight,
+            correction_count=correction_count,
         )
-        signal = Signal(
-            episode_id=episode.id,
-            signal_type="CORRECTION",
-            raw_value=float(correction_count),
-            multiplier=weight,
-        )
-        self._db.save_signal(signal)
-        return episode
 
     def get_episode(self, episode_id: str) -> Optional[Episode]:
         return self._db.get_episode(episode_id)

--- a/neurosync/mcp_server.py
+++ b/neurosync/mcp_server.py
@@ -20,7 +20,9 @@ from neurosync.hierarchy import TheoryHierarchy
 from neurosync.logging import configure_logging, get_logger
 from neurosync.models import EPISODE_TYPES
 from neurosync.quality import quality_warning
+from neurosync.retrieval import RetrievalPipeline
 from neurosync.semantic import SemanticMemory
+from neurosync.user_model import UserModel
 from neurosync.vectorstore import VectorStore
 from neurosync.version import __version__
 from neurosync.working import WorkingMemory
@@ -345,15 +347,19 @@ _causal: Optional[CausalGraph] = None
 _failure: Optional[FailureModel] = None
 _forgetting: Optional[ForgettingEngine] = None
 _hierarchy: Optional[TheoryHierarchy] = None
+_user_model: Optional[UserModel] = None
+_retrieval: Optional[RetrievalPipeline] = None
 _graph: Optional[Any] = None
 _current_session_id: Optional[str] = None
 _correction_count: int = 0
+_correction_topics: list[str] = []  # Topics corrected this session (for targeted penalization)
 _git_observer: Optional[GitObserver] = None
 
 
 def _init() -> None:
     global _config, _db, _vs, _episodic, _semantic, _working
     global _analogy, _causal, _failure, _forgetting, _hierarchy
+    global _user_model, _retrieval
     if _db is not None:
         return
 
@@ -362,7 +368,21 @@ def _init() -> None:
     configure_logging()
 
     # Database is essential — failure here is fatal
-    db = Database(config)
+    # Use PostgreSQL when configured, SQLite otherwise
+    db: Any
+    if config.db_backend == "postgresql":
+        try:
+            from neurosync.pg_db import PostgresDatabase
+            db = PostgresDatabase(config)
+            logger.info("Using PostgreSQL backend")
+        except ImportError:
+            logger.warning("psycopg2 not installed, falling back to SQLite")
+            db = Database(config)
+        except Exception:
+            logger.warning("PostgreSQL connection failed, falling back to SQLite", exc_info=True)
+            db = Database(config)
+    else:
+        db = Database(config)
 
     # VectorStore is optional — failure means degraded mode
     vs = None
@@ -380,6 +400,8 @@ def _init() -> None:
     failure = FailureModel(db, vs)
     forgetting = ForgettingEngine(db, vs)
     hierarchy = TheoryHierarchy(db, vs)
+    user_model = UserModel(db)
+    retrieval = RetrievalPipeline(db, vs, user_model=user_model, semantic=semantic)
 
     # Atomic commit — all or nothing
     _config = config
@@ -393,6 +415,8 @@ def _init() -> None:
     _failure = failure
     _forgetting = forgetting
     _hierarchy = hierarchy
+    _user_model = user_model
+    _retrieval = retrieval
 
 
 def _ensure_session(project: str = "", branch: str = "") -> str:
@@ -436,11 +460,19 @@ def _get_graph():
 def _try_auto_consolidate() -> Optional[dict]:
     """Run auto-consolidation if enabled and threshold is met. Returns result or None."""
     if _config and _config.auto_consolidation_enabled and _db and _vs and _episodic and _semantic:
-        return maybe_consolidate(
+        result = maybe_consolidate(
             _db, _vs, _episodic, _semantic,
             threshold=_config.auto_consolidation_threshold,
             min_episodes=_config.consolidation_min_episodes,
         )
+        # Run forgetting pass after consolidation to prune stale episodes and decay theories
+        if result and _forgetting:
+            try:
+                forget_result = _forgetting.run_forgetting_pass()
+                result["forgetting"] = forget_result
+            except Exception:
+                logger.debug("Forgetting pass failed after consolidation", exc_info=True)
+        return result
     return None
 
 
@@ -450,13 +482,14 @@ def _try_auto_consolidate() -> Optional[dict]:
 
 
 def handle_recall(params: dict[str, Any]) -> dict[str, Any]:
-    _require_init(_working, _failure, _hierarchy)
+    _require_init(_retrieval, _failure, _hierarchy, _forgetting)
     git_info = detect_git_info()
     project = params.get("project") or git_info.get("project", "")
     branch = params.get("branch") or git_info.get("branch", "")
     context = params.get("context", "")
     max_tokens = params.get("max_tokens", 500)
-    result = _working.recall(
+    # Use RetrievalPipeline (includes UserModel filtering, parent context, continuations)
+    result = _retrieval.recall(
         project=project,
         branch=branch,
         context=context,
@@ -467,6 +500,27 @@ def handle_recall(params: dict[str, Any]) -> dict[str, Any]:
             "neurosync_recall",
             {"message": "No memories yet. Start working and record episodes to build memory."},
         )
+    # Track user exposure to recalled theories (feeds UserModel familiarity)
+    if _user_model and project:
+        if result.get("primary"):
+            _user_model.record_exposure(
+                topic=result["primary"]["content"][:100],
+                project=project,
+                explained=False,
+            )
+        for sup in result.get("supporting", []):
+            _user_model.record_exposure(
+                topic=sup["content"][:100],
+                project=project,
+                explained=False,
+            )
+    # Refresh primary theory's retention (extends Ebbinghaus grace period)
+    if result.get("primary") and _forgetting:
+        primary_id = result["primary"].get("id", "")
+        if primary_id:
+            theory = _db.get_theory(primary_id)
+            if theory:
+                _forgetting.refresh_theory_on_application(theory)
     # Enrich with failure warnings
     query = f"{project} {branch} {context}".strip()
     if query:
@@ -498,18 +552,47 @@ def handle_record(params: dict[str, Any]) -> dict[str, Any]:
         event_type = event.get("type", "decision")
         if event_type not in EPISODE_TYPES:
             event_type = "decision"
+        content = event.get("content", "")
+        layers = event.get("layers", [])
+        # Compute SURPRISE signal: check if content contradicts any existing theory
+        contradicts = False
+        if _vs and content.strip():
+            try:
+                similar = _vs.search_theories(content, n_results=3, active_only=True)
+                for match in similar:
+                    dist = match.get("distance", 1.0)
+                    # Low distance = similar topic; check if content has contradiction language
+                    if dist < 0.4 and _has_contradiction_language(content):
+                        contradicts = True
+                        break
+            except Exception:
+                pass
+        # Compute REPETITION signal: check if user has explained this topic before
+        times_explained = 0
+        if _user_model and content.strip():
+            topic_key = content[:100]
+            uk = _db.get_user_knowledge(topic_key, project)
+            if uk:
+                times_explained = uk.times_explained
         episode = _episodic.record_episode(
             session_id=session_id,
             event_type=event_type,
-            content=event.get("content", ""),
+            content=content,
             files_touched=event.get("files", []),
-            layers_touched=event.get("layers", []),
+            layers_touched=layers,
             cause=event.get("cause", ""),
             effect=event.get("effect", ""),
             reasoning=event.get("reasoning", ""),
             importance=event.get("importance", 0),
+            contradicts_theory=contradicts,
+            times_explained=times_explained,
         )
         recorded.append(episode.id)
+        # Track user exposure when they explain something
+        if _user_model and project and content.strip():
+            _user_model.record_exposure(
+                topic=content[:100], project=project, explained=True,
+            )
         # Check quality
         if episode.quality_score is not None:
             warn = quality_warning(episode.quality_score)
@@ -534,6 +617,10 @@ def handle_record(params: dict[str, Any]) -> dict[str, Any]:
             observed_count += 1
     if summary:
         _episodic.end_session(session_id, summary=summary)
+    # Outcome-based confidence: if session had corrections, slightly reduce
+    # confidence of theories that were recalled but led to mistakes
+    if _correction_count > 0 and _semantic:
+        _apply_outcome_confidence_adjustment()
     result: dict[str, Any] = {
         "session_id": session_id,
         "episodes_recorded": len(recorded),
@@ -550,17 +637,112 @@ def handle_record(params: dict[str, Any]) -> dict[str, Any]:
     return _add_protocol_hint("neurosync_record", result)
 
 
+def _has_contradiction_language(text: str) -> bool:
+    """Check if text contains strong contradiction/correction indicators.
+
+    Uses multi-word phrases and strong negation patterns to avoid false
+    positives from common words like "instead" or "however" that appear
+    in normal technical writing.
+    """
+    # Strong indicators: phrases that strongly imply contradiction
+    strong_markers = (
+        "but actually", "not true", "this is wrong", "was wrong",
+        "is incorrect", "was incorrect", "doesn't work", "didn't work",
+        "this is broken", "was broken", "should not have",
+        "contrary to", "opposite of", "contradicts",
+        "that's a mistake", "was a mistake", "corrected to",
+        "the correct approach", "the right way", "not actually",
+    )
+    text_lower = text.lower()
+    if any(m in text_lower for m in strong_markers):
+        return True
+    # Require at least 2 weak indicators to trigger (co-occurrence reduces false positives)
+    weak_markers = (
+        "actually", "incorrect", "wrong", "mistake",
+        "corrected", "instead", "rather", "however",
+        "contrary", "broken",
+    )
+    weak_count = sum(1 for m in weak_markers if m in text_lower)
+    return weak_count >= 2
+
+
+def _apply_outcome_confidence_adjustment() -> None:
+    """Outcome-based confidence: reduce confidence of recently-applied theories
+    only when the correction topic is relevant to the theory content.
+
+    Uses Hebbian specificity: only weaken the activated pathway (theory whose
+    content overlaps with the correction), not all active theories globally.
+    """
+    if not _semantic or not _db or not _correction_topics:
+        return
+    try:
+        theories = _db.list_theories(active_only=True, limit=50)
+        penalty = min(_correction_count * 0.02, 0.1)  # Cap at 10% reduction
+        for theory in theories:
+            if not theory.last_applied or theory.application_count <= 0:
+                continue
+            # Only penalize if the theory's content is relevant to a correction topic
+            theory_lower = theory.content.lower()
+            relevant = any(
+                _topic_overlap(topic, theory_lower)
+                for topic in _correction_topics
+            )
+            if relevant:
+                theory.confidence = max(0.05, theory.confidence - penalty)
+                _db.save_theory(theory)
+    except Exception:
+        logger.debug("Outcome confidence adjustment failed", exc_info=True)
+
+
+def _topic_overlap(correction_text: str, theory_text: str) -> bool:
+    """Check if a correction topic is semantically related to a theory.
+
+    Uses keyword overlap: splits correction into significant words (3+ chars)
+    and checks if at least 2 appear in the theory, or if the full correction
+    phrase appears as a substring.
+    """
+    if correction_text in theory_text:
+        return True
+    words = [w for w in correction_text.split() if len(w) >= 3]
+    if not words:
+        return False
+    matches = sum(1 for w in words if w in theory_text)
+    # Require at least 2 keyword matches, or >40% overlap for short phrases
+    threshold = min(2, max(1, len(words) * 4 // 10))
+    return matches >= threshold
+
+
 def handle_remember(params: dict[str, Any]) -> dict[str, Any]:
     _require_init(_episodic)
     content = params.get("content", "")
     event_type = params.get("type", "explicit")
+    cause = params.get("cause", "")
+    effect = params.get("effect", "")
+    reasoning = params.get("reasoning", "")
+    importance = params.get("importance", 0)
     if not content.strip():
         return {"error": "Content is required"}
+    # Build enriched content with causal context if provided
+    enriched = content
+    if cause or effect:
+        parts = []
+        if cause:
+            parts.append(f"Cause: {cause}")
+        parts.append(content)
+        if effect:
+            parts.append(f"Effect: {effect}")
+        if reasoning:
+            parts.append(f"Reasoning: {reasoning}")
+        enriched = " | ".join(parts)
     session_id = _ensure_session()
     episode = _episodic.record_explicit(
         session_id=session_id,
-        content=content,
+        content=enriched,
         event_type=event_type,
+        importance=importance,
+        cause=cause,
+        effect=effect,
+        reasoning=reasoning,
     )
     result: dict[str, Any] = {
         "episode_id": episode.id,
@@ -608,7 +790,7 @@ def handle_query(params: dict[str, Any]) -> dict[str, Any]:
 
 
 def handle_correct(params: dict[str, Any]) -> dict[str, Any]:
-    global _correction_count
+    global _correction_count, _correction_topics
     _require_init(_episodic, _semantic, _failure)
     wrong = params.get("wrong", "")
     right = params.get("right", "")
@@ -616,6 +798,9 @@ def handle_correct(params: dict[str, Any]) -> dict[str, Any]:
     if not wrong.strip() or not right.strip():
         return {"error": "Both 'wrong' and 'right' are required"}
     _correction_count += 1
+    # Track correction topics for targeted confidence adjustment
+    _correction_topics.append(wrong.lower())
+    _correction_topics.append(right.lower())
     session_id = _ensure_session()
     episode = _episodic.record_correction(
         session_id=session_id,
@@ -640,6 +825,14 @@ def handle_correct(params: dict[str, Any]) -> dict[str, Any]:
     failure_rec = _failure.extract_from_correction(episode.id)
     if failure_rec:
         result["failure_record_id"] = failure_rec.id
+    # Track correction in user model
+    if _user_model:
+        git_info = detect_git_info()
+        proj = git_info.get("project", "")
+        # Record the wrong thing as a correction topic (we were wrong about it)
+        _user_model.record_correction_on_topic(topic=wrong[:100], project=proj)
+        # Record the right thing as exposure (user now knows this)
+        _user_model.record_exposure(topic=right[:100], project=proj, explained=True)
     auto_result = _try_auto_consolidate()
     if auto_result:
         result["auto_consolidation"] = auto_result
@@ -775,6 +968,13 @@ def handle_consolidate(params: dict[str, Any]) -> dict[str, Any]:
         from neurosync.consolidation import ConsolidationEngine
         engine = ConsolidationEngine(_db, _vs, _episodic, _semantic)
         result = engine.run(project=params.get("project"), dry_run=False)
+        # Run forgetting pass after manual consolidation
+        if _forgetting:
+            try:
+                forget_result = _forgetting.run_forgetting_pass()
+                result["forgetting"] = forget_result
+            except Exception:
+                logger.debug("Forgetting pass failed after consolidation", exc_info=True)
         return result
     except ImportError:
         return {

--- a/neurosync/pg_db.py
+++ b/neurosync/pg_db.py
@@ -1,0 +1,1049 @@
+"""PostgreSQL database backend: schema init, migrations, connection pooling.
+
+Drop-in replacement for db.Database when db_backend='postgresql'.
+Requires psycopg2: pip install neurosync[postgresql]
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+from typing import Any, Optional
+
+from neurosync.config import NeuroSyncConfig
+from neurosync.logging import get_logger
+from neurosync.models import (
+    CausalLink,
+    Contradiction,
+    Episode,
+    FailureRecord,
+    Session,
+    Signal,
+    Theory,
+    UserKnowledge,
+    _utcnow,
+)
+
+logger = get_logger("pg_db")
+
+CURRENT_SCHEMA_VERSION = 5
+
+# PostgreSQL schema — uses SERIAL instead of AUTOINCREMENT, BOOLEAN instead of
+# INTEGER for booleans, and native JSON handling.
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    project TEXT NOT NULL DEFAULT '',
+    branch TEXT NOT NULL DEFAULT '',
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    duration_seconds INTEGER DEFAULT 0,
+    summary TEXT DEFAULT '',
+    metadata JSONB DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS episodes (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    timestamp TEXT NOT NULL,
+    event_type TEXT NOT NULL DEFAULT 'decision',
+    content TEXT NOT NULL DEFAULT '',
+    context TEXT DEFAULT '',
+    files_touched JSONB DEFAULT '[]',
+    layers_touched JSONB DEFAULT '[]',
+    signal_weight REAL DEFAULT 1.0,
+    consolidated INTEGER DEFAULT 0,
+    consolidated_at TEXT,
+    cause TEXT DEFAULT '',
+    effect TEXT DEFAULT '',
+    reasoning TEXT DEFAULT '',
+    quality_score INTEGER,
+    metadata JSONB DEFAULT '{}',
+    reinforcement_count INTEGER DEFAULT 0,
+    last_accessed TEXT,
+    structural_fingerprint TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_episodes_session ON episodes(session_id);
+CREATE INDEX IF NOT EXISTS idx_episodes_consolidated ON episodes(consolidated);
+CREATE INDEX IF NOT EXISTS idx_episodes_type ON episodes(event_type);
+
+CREATE TABLE IF NOT EXISTS signals (
+    id SERIAL PRIMARY KEY,
+    episode_id TEXT NOT NULL REFERENCES episodes(id),
+    signal_type TEXT NOT NULL,
+    raw_value REAL DEFAULT 0.0,
+    multiplier REAL DEFAULT 1.0,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_signals_episode ON signals(episode_id);
+
+CREATE TABLE IF NOT EXISTS theories (
+    id TEXT PRIMARY KEY,
+    content TEXT NOT NULL DEFAULT '',
+    scope TEXT NOT NULL DEFAULT 'craft',
+    scope_qualifier TEXT DEFAULT '',
+    confidence REAL DEFAULT 0.5,
+    confirmation_count INTEGER DEFAULT 0,
+    contradiction_count INTEGER DEFAULT 0,
+    first_observed TEXT NOT NULL,
+    last_confirmed TEXT,
+    source_episodes JSONB DEFAULT '[]',
+    superseded_by TEXT,
+    active BOOLEAN DEFAULT TRUE,
+    description_length INTEGER DEFAULT 0,
+    parent_theory_id TEXT,
+    related_theories JSONB DEFAULT '[]',
+    last_applied TEXT,
+    application_count INTEGER DEFAULT 0,
+    validation_status TEXT DEFAULT 'unvalidated',
+    metadata JSONB DEFAULT '{}',
+    hierarchy_depth INTEGER DEFAULT 0,
+    structural_fingerprint TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_theories_active ON theories(active);
+CREATE INDEX IF NOT EXISTS idx_theories_scope ON theories(scope);
+CREATE INDEX IF NOT EXISTS idx_theories_parent ON theories(parent_theory_id);
+
+CREATE TABLE IF NOT EXISTS contradictions (
+    id SERIAL PRIMARY KEY,
+    theory_id TEXT NOT NULL REFERENCES theories(id),
+    episode_id TEXT NOT NULL REFERENCES episodes(id),
+    description TEXT DEFAULT '',
+    resolution TEXT,
+    resolved_at TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user_model (
+    id SERIAL PRIMARY KEY,
+    topic TEXT NOT NULL,
+    project TEXT DEFAULT '',
+    familiarity REAL DEFAULT 0.5,
+    last_seen TEXT NOT NULL,
+    times_seen INTEGER DEFAULT 0,
+    times_explained INTEGER DEFAULT 0,
+    metadata JSONB DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_user_model_topic ON user_model(topic);
+
+CREATE TABLE IF NOT EXISTS causal_links (
+    id SERIAL PRIMARY KEY,
+    cause_text TEXT NOT NULL,
+    effect_text TEXT NOT NULL,
+    mechanism TEXT NOT NULL DEFAULT 'direct',
+    mechanism_detail TEXT DEFAULT '',
+    confidence_level TEXT DEFAULT 'observed',
+    strength REAL DEFAULT 0.5,
+    observation_count INTEGER DEFAULT 1,
+    source_episode_ids JSONB DEFAULT '[]',
+    source_theory_id TEXT DEFAULT '',
+    project TEXT DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    cause_text_normalized TEXT DEFAULT '',
+    effect_text_normalized TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_causal_cause ON causal_links(cause_text);
+CREATE INDEX IF NOT EXISTS idx_causal_effect ON causal_links(effect_text);
+CREATE INDEX IF NOT EXISTS idx_causal_project ON causal_links(project);
+CREATE INDEX IF NOT EXISTS idx_causal_cause_effect ON causal_links(cause_text, effect_text);
+CREATE INDEX IF NOT EXISTS idx_causal_normalized ON causal_links(cause_text_normalized, effect_text_normalized);
+
+CREATE TABLE IF NOT EXISTS failure_records (
+    id SERIAL PRIMARY KEY,
+    what_failed TEXT NOT NULL,
+    why_failed TEXT NOT NULL DEFAULT '',
+    what_worked TEXT DEFAULT '',
+    category TEXT DEFAULT 'approach',
+    project TEXT DEFAULT '',
+    context TEXT DEFAULT '',
+    source_episode_id TEXT DEFAULT '',
+    severity INTEGER DEFAULT 3,
+    occurrence_count INTEGER DEFAULT 1,
+    created_at TEXT NOT NULL,
+    last_seen TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_failures_project ON failure_records(project);
+CREATE INDEX IF NOT EXISTS idx_failures_category ON failure_records(category);
+
+CREATE TABLE IF NOT EXISTS theory_episodes (
+    theory_id TEXT NOT NULL, episode_id TEXT NOT NULL,
+    PRIMARY KEY (theory_id, episode_id)
+);
+CREATE INDEX IF NOT EXISTS idx_te_episode ON theory_episodes(episode_id);
+
+CREATE TABLE IF NOT EXISTS theory_relations (
+    theory_id TEXT NOT NULL, related_theory_id TEXT NOT NULL,
+    PRIMARY KEY (theory_id, related_theory_id)
+);
+CREATE INDEX IF NOT EXISTS idx_tr_related ON theory_relations(related_theory_id);
+
+CREATE TABLE IF NOT EXISTS causal_link_episodes (
+    causal_link_id INTEGER NOT NULL, episode_id TEXT NOT NULL,
+    PRIMARY KEY (causal_link_id, episode_id)
+);
+CREATE INDEX IF NOT EXISTS idx_cle_episode ON causal_link_episodes(episode_id);
+
+CREATE TABLE IF NOT EXISTS entity_fingerprints (
+    entity_id TEXT NOT NULL, entity_type TEXT NOT NULL, pattern TEXT NOT NULL,
+    PRIMARY KEY (entity_id, entity_type, pattern)
+);
+CREATE INDEX IF NOT EXISTS idx_efp_pattern ON entity_fingerprints(pattern);
+CREATE INDEX IF NOT EXISTS idx_efp_entity ON entity_fingerprints(entity_id, entity_type);
+"""
+
+
+class PostgresDatabase:
+    """PostgreSQL database backend for NeuroSync.
+
+    Same public interface as db.Database (SQLite), backed by psycopg2
+    with connection pooling.
+    """
+
+    def __init__(self, config: NeuroSyncConfig) -> None:
+        try:
+            import psycopg2
+            import psycopg2.pool
+        except ImportError as e:
+            raise ImportError(
+                "psycopg2 is required for PostgreSQL backend. "
+                "Install with: pip install neurosync[postgresql]"
+            ) from e
+
+        self._config = config
+        self._lock = threading.Lock()
+        self._pool = psycopg2.pool.ThreadedConnectionPool(
+            minconn=1,
+            maxconn=5,
+            dsn=config.pg_dsn,
+        )
+        self._init_schema()
+
+    def __enter__(self) -> PostgresDatabase:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def _get_conn(self) -> Any:
+        return self._pool.getconn()
+
+    def _put_conn(self, conn: Any) -> None:
+        self._pool.putconn(conn)
+
+    def _execute(self, sql: str, params: Any = None, returning: bool = False) -> Any:
+        """Execute a single SQL statement with automatic connection management."""
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                if returning:
+                    result = cur.fetchone()
+                    conn.commit()
+                    return result
+                conn.commit()
+                return cur
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            self._put_conn(conn)
+
+    def _query(self, sql: str, params: Any = None) -> list[dict[str, Any]]:
+        """Execute a query and return results as list of dicts."""
+        conn = self._get_conn()
+        try:
+            import psycopg2.extras
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(sql, params)
+                return [dict(row) for row in cur.fetchall()]
+        finally:
+            self._put_conn(conn)
+
+    def _query_one(self, sql: str, params: Any = None) -> Optional[dict[str, Any]]:
+        """Execute a query and return first result as dict, or None."""
+        rows = self._query(sql, params)
+        return rows[0] if rows else None
+
+    def _init_schema(self) -> None:
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                # Check if schema_version table exists
+                cur.execute(
+                    "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='schema_version')"
+                )
+                exists = cur.fetchone()[0]
+
+                if exists:
+                    cur.execute("SELECT version FROM schema_version")
+                    row = cur.fetchone()
+                    if row and row[0] < CURRENT_SCHEMA_VERSION:
+                        # Migrations would go here — for now, fresh installs only
+                        cur.execute(
+                            "UPDATE schema_version SET version = %s",
+                            (CURRENT_SCHEMA_VERSION,),
+                        )
+                else:
+                    # Fresh DB — split and execute each statement individually
+                    for stmt in _SCHEMA_SQL.split(';'):
+                        stmt = stmt.strip()
+                        if stmt:
+                            cur.execute(stmt)
+                    cur.execute(
+                        "INSERT INTO schema_version (version) VALUES (%s)",
+                        (CURRENT_SCHEMA_VERSION,),
+                    )
+                conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            self._put_conn(conn)
+
+    def close(self) -> None:
+        if self._pool:
+            self._pool.closeall()
+
+    # --- JSON helpers ---
+
+    @staticmethod
+    def _to_json(val: Any) -> str:
+        return json.dumps(val, default=str)
+
+    @staticmethod
+    def _from_json(val: Any, fallback: Any = None) -> Any:
+        if val is None:
+            return fallback if fallback is not None else {}
+        if isinstance(val, (dict, list)):
+            return val  # psycopg2 auto-deserializes JSONB
+        if isinstance(val, str):
+            try:
+                return json.loads(val)
+            except (json.JSONDecodeError, TypeError):
+                return fallback if fallback is not None else {}
+        return fallback if fallback is not None else {}
+
+    @staticmethod
+    def _normalize_text(text: str) -> str:
+        return re.sub(r'\s+', ' ', text.strip().lower())
+
+    # --- Sessions ---
+
+    def save_session(self, session: Session) -> Session:
+        self._execute(
+            """INSERT INTO sessions
+               (id, project, branch, started_at, ended_at, duration_seconds, summary, metadata)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+               ON CONFLICT (id) DO UPDATE SET
+               project=EXCLUDED.project, branch=EXCLUDED.branch,
+               started_at=EXCLUDED.started_at, ended_at=EXCLUDED.ended_at,
+               duration_seconds=EXCLUDED.duration_seconds, summary=EXCLUDED.summary,
+               metadata=EXCLUDED.metadata""",
+            (
+                session.id, session.project, session.branch,
+                session.started_at, session.ended_at, session.duration_seconds,
+                session.summary, self._to_json(session.metadata),
+            ),
+        )
+        return session
+
+    def get_session(self, session_id: str) -> Optional[Session]:
+        row = self._query_one("SELECT * FROM sessions WHERE id = %s", (session_id,))
+        return self._row_to_session(row) if row else None
+
+    def list_sessions(self, project: Optional[str] = None, limit: int = 20) -> list[Session]:
+        if project:
+            rows = self._query(
+                "SELECT * FROM sessions WHERE project = %s ORDER BY started_at DESC LIMIT %s",
+                (project, limit),
+            )
+        else:
+            rows = self._query(
+                "SELECT * FROM sessions ORDER BY started_at DESC LIMIT %s", (limit,)
+            )
+        return [self._row_to_session(r) for r in rows]
+
+    def _row_to_session(self, row: dict[str, Any]) -> Session:
+        return Session(
+            id=row["id"], project=row["project"], branch=row["branch"],
+            started_at=row["started_at"], ended_at=row["ended_at"],
+            duration_seconds=row["duration_seconds"], summary=row["summary"],
+            metadata=self._from_json(row["metadata"], {}),
+        )
+
+    # --- Episodes ---
+
+    def save_episode(self, episode: Episode) -> Episode:
+        self._execute(
+            """INSERT INTO episodes
+               (id, session_id, timestamp, event_type, content, context,
+                files_touched, layers_touched, signal_weight, consolidated,
+                consolidated_at, cause, effect, reasoning, quality_score, metadata,
+                reinforcement_count, last_accessed, structural_fingerprint)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+               ON CONFLICT (id) DO UPDATE SET
+               signal_weight=EXCLUDED.signal_weight, consolidated=EXCLUDED.consolidated,
+               consolidated_at=EXCLUDED.consolidated_at, quality_score=EXCLUDED.quality_score,
+               metadata=EXCLUDED.metadata, reinforcement_count=EXCLUDED.reinforcement_count,
+               last_accessed=EXCLUDED.last_accessed, structural_fingerprint=EXCLUDED.structural_fingerprint""",
+            (
+                episode.id, episode.session_id, episode.timestamp, episode.event_type,
+                episode.content, episode.context,
+                self._to_json(episode.files_touched), self._to_json(episode.layers_touched),
+                episode.signal_weight, episode.consolidated, episode.consolidated_at,
+                episode.cause, episode.effect, episode.reasoning, episode.quality_score,
+                self._to_json(episode.metadata), episode.reinforcement_count,
+                episode.last_accessed, episode.structural_fingerprint,
+            ),
+        )
+        return episode
+
+    def get_episode(self, episode_id: str) -> Optional[Episode]:
+        row = self._query_one("SELECT * FROM episodes WHERE id = %s", (episode_id,))
+        return self._row_to_episode(row) if row else None
+
+    def list_episodes(
+        self, session_id: Optional[str] = None, consolidated: Optional[int] = None,
+        event_type: Optional[str] = None, limit: int = 100,
+    ) -> list[Episode]:
+        clauses = []
+        params: list[Any] = []
+        if session_id is not None:
+            clauses.append("session_id = %s")
+            params.append(session_id)
+        if consolidated is not None:
+            clauses.append("consolidated = %s")
+            params.append(consolidated)
+        if event_type is not None:
+            clauses.append("event_type = %s")
+            params.append(event_type)
+        where = " AND ".join(clauses) if clauses else "TRUE"
+        params.append(limit)
+        rows = self._query(
+            f"SELECT * FROM episodes WHERE {where} ORDER BY timestamp DESC LIMIT %s",
+            params,
+        )
+        return [self._row_to_episode(r) for r in rows]
+
+    def count_episodes(self, consolidated: Optional[int] = None) -> int:
+        if consolidated is not None:
+            row = self._query_one(
+                "SELECT COUNT(*) AS cnt FROM episodes WHERE consolidated = %s", (consolidated,)
+            )
+        else:
+            row = self._query_one("SELECT COUNT(*) AS cnt FROM episodes")
+        return row["cnt"] if row else 0
+
+    def mark_episodes_consolidated(self, episode_ids: list[str], timestamp: str) -> None:
+        if not episode_ids:
+            return
+        self._execute(
+            "UPDATE episodes SET consolidated = 1, consolidated_at = %s WHERE id = ANY(%s)",
+            (timestamp, episode_ids),
+        )
+
+    def mark_episodes_decayed(self, episode_ids: list[str]) -> None:
+        if not episode_ids:
+            return
+        self._execute(
+            "UPDATE episodes SET consolidated = 2 WHERE id = ANY(%s)",
+            (episode_ids,),
+        )
+
+    def _row_to_episode(self, row: dict[str, Any]) -> Episode:
+        return Episode(
+            id=row["id"], session_id=row["session_id"], timestamp=row["timestamp"],
+            event_type=row["event_type"], content=row["content"],
+            context=row["context"] or "",
+            files_touched=self._from_json(row["files_touched"], []),
+            layers_touched=self._from_json(row["layers_touched"], []),
+            signal_weight=row["signal_weight"], consolidated=row["consolidated"],
+            consolidated_at=row["consolidated_at"],
+            cause=row["cause"] or "", effect=row["effect"] or "",
+            reasoning=row["reasoning"] or "",
+            quality_score=row["quality_score"],
+            metadata=self._from_json(row["metadata"], {}),
+            reinforcement_count=row["reinforcement_count"] or 0,
+            last_accessed=row["last_accessed"],
+            structural_fingerprint=row["structural_fingerprint"] or "",
+        )
+
+    # --- Signals ---
+
+    def save_signal(self, signal: Signal) -> Signal:
+        result = self._execute(
+            """INSERT INTO signals (episode_id, signal_type, raw_value, multiplier, timestamp)
+               VALUES (%s, %s, %s, %s, %s) RETURNING id""",
+            (signal.episode_id, signal.signal_type, signal.raw_value,
+             signal.multiplier, signal.timestamp),
+            returning=True,
+        )
+        if result:
+            signal.id = result[0]
+        return signal
+
+    def get_signals_for_episode(self, episode_id: str) -> list[Signal]:
+        rows = self._query(
+            "SELECT * FROM signals WHERE episode_id = %s", (episode_id,)
+        )
+        return [
+            Signal(id=r["id"], episode_id=r["episode_id"], signal_type=r["signal_type"],
+                   raw_value=r["raw_value"], multiplier=r["multiplier"],
+                   timestamp=r["timestamp"])
+            for r in rows
+        ]
+
+    # --- Theories ---
+
+    def save_theory(self, theory: Theory) -> Theory:
+        self._execute(
+            """INSERT INTO theories
+               (id, content, scope, scope_qualifier, confidence, confirmation_count,
+                contradiction_count, first_observed, last_confirmed, source_episodes,
+                superseded_by, active, description_length, parent_theory_id,
+                related_theories, last_applied, application_count, validation_status,
+                metadata, hierarchy_depth, structural_fingerprint)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+               ON CONFLICT (id) DO UPDATE SET
+               content=EXCLUDED.content, confidence=EXCLUDED.confidence,
+               confirmation_count=EXCLUDED.confirmation_count,
+               contradiction_count=EXCLUDED.contradiction_count,
+               last_confirmed=EXCLUDED.last_confirmed,
+               source_episodes=EXCLUDED.source_episodes,
+               superseded_by=EXCLUDED.superseded_by, active=EXCLUDED.active,
+               description_length=EXCLUDED.description_length,
+               parent_theory_id=EXCLUDED.parent_theory_id,
+               related_theories=EXCLUDED.related_theories,
+               last_applied=EXCLUDED.last_applied,
+               application_count=EXCLUDED.application_count,
+               validation_status=EXCLUDED.validation_status,
+               metadata=EXCLUDED.metadata,
+               hierarchy_depth=EXCLUDED.hierarchy_depth,
+               structural_fingerprint=EXCLUDED.structural_fingerprint""",
+            (
+                theory.id, theory.content, theory.scope, theory.scope_qualifier,
+                theory.confidence, theory.confirmation_count,
+                theory.contradiction_count, theory.first_observed,
+                theory.last_confirmed, self._to_json(theory.source_episodes),
+                theory.superseded_by, theory.active,
+                theory.description_length, theory.parent_theory_id,
+                self._to_json(theory.related_theories), theory.last_applied,
+                theory.application_count, theory.validation_status,
+                self._to_json(theory.metadata), theory.hierarchy_depth,
+                theory.structural_fingerprint,
+            ),
+        )
+        return theory
+
+    def get_theory(self, theory_id: str) -> Optional[Theory]:
+        row = self._query_one("SELECT * FROM theories WHERE id = %s", (theory_id,))
+        return self._row_to_theory(row) if row else None
+
+    def list_theories(
+        self, active_only: bool = True, scope: Optional[str] = None,
+        project: Optional[str] = None, limit: int = 50,
+    ) -> list[Theory]:
+        clauses = []
+        params: list[Any] = []
+        if active_only:
+            clauses.append("active = TRUE")
+        if scope:
+            clauses.append("scope = %s")
+            params.append(scope)
+        if project:
+            clauses.append("scope_qualifier = %s")
+            params.append(project)
+        where = " AND ".join(clauses) if clauses else "TRUE"
+        params.append(limit)
+        rows = self._query(
+            f"SELECT * FROM theories WHERE {where} ORDER BY confidence DESC LIMIT %s",
+            params,
+        )
+        return [self._row_to_theory(r) for r in rows]
+
+    def count_theories(self, active_only: bool = True) -> int:
+        if active_only:
+            row = self._query_one("SELECT COUNT(*) AS cnt FROM theories WHERE active = TRUE")
+        else:
+            row = self._query_one("SELECT COUNT(*) AS cnt FROM theories")
+        return row["cnt"] if row else 0
+
+    def _row_to_theory(self, row: dict[str, Any]) -> Theory:
+        return Theory(
+            id=row["id"], content=row["content"], scope=row["scope"],
+            scope_qualifier=row["scope_qualifier"], confidence=row["confidence"],
+            confirmation_count=row["confirmation_count"],
+            contradiction_count=row["contradiction_count"],
+            first_observed=row["first_observed"],
+            last_confirmed=row["last_confirmed"],
+            source_episodes=self._from_json(row["source_episodes"], []),
+            superseded_by=row["superseded_by"],
+            active=bool(row["active"]),
+            description_length=row["description_length"],
+            parent_theory_id=row["parent_theory_id"],
+            related_theories=self._from_json(row["related_theories"], []),
+            last_applied=row["last_applied"],
+            application_count=row["application_count"] or 0,
+            validation_status=row["validation_status"] or "unvalidated",
+            metadata=self._from_json(row["metadata"], {}),
+            hierarchy_depth=row["hierarchy_depth"] or 0,
+            structural_fingerprint=row["structural_fingerprint"] or "",
+        )
+
+    # --- Contradictions ---
+
+    def save_contradiction(self, contradiction: Contradiction) -> Contradiction:
+        result = self._execute(
+            """INSERT INTO contradictions
+               (theory_id, episode_id, description, resolution, resolved_at, created_at)
+               VALUES (%s, %s, %s, %s, %s, %s) RETURNING id""",
+            (contradiction.theory_id, contradiction.episode_id,
+             contradiction.description, contradiction.resolution,
+             contradiction.resolved_at, contradiction.created_at),
+            returning=True,
+        )
+        if result:
+            contradiction.id = result[0]
+        return contradiction
+
+    def list_contradictions(
+        self, theory_id: Optional[str] = None, unresolved_only: bool = False,
+        limit: int = 50,
+    ) -> list[Contradiction]:
+        clauses = []
+        params: list[Any] = []
+        if theory_id:
+            clauses.append("theory_id = %s")
+            params.append(theory_id)
+        if unresolved_only:
+            clauses.append("resolved_at IS NULL")
+        where = " AND ".join(clauses) if clauses else "TRUE"
+        params.append(limit)
+        rows = self._query(
+            f"SELECT * FROM contradictions WHERE {where} ORDER BY created_at DESC LIMIT %s",
+            params,
+        )
+        return [
+            Contradiction(
+                id=r["id"], theory_id=r["theory_id"], episode_id=r["episode_id"],
+                description=r["description"], resolution=r["resolution"],
+                resolved_at=r["resolved_at"], created_at=r["created_at"],
+            )
+            for r in rows
+        ]
+
+    def count_contradictions(self, unresolved_only: bool = False) -> int:
+        if unresolved_only:
+            row = self._query_one(
+                "SELECT COUNT(*) AS cnt FROM contradictions WHERE resolved_at IS NULL"
+            )
+        else:
+            row = self._query_one("SELECT COUNT(*) AS cnt FROM contradictions")
+        return row["cnt"] if row else 0
+
+    # --- User Model ---
+
+    def save_user_knowledge(self, uk: UserKnowledge) -> UserKnowledge:
+        if uk.id is not None:
+            self._execute(
+                """UPDATE user_model SET topic=%s, project=%s, familiarity=%s,
+                   last_seen=%s, times_seen=%s, times_explained=%s, metadata=%s
+                   WHERE id=%s""",
+                (uk.topic, uk.project, uk.familiarity, uk.last_seen,
+                 uk.times_seen, uk.times_explained, self._to_json(uk.metadata), uk.id),
+            )
+        else:
+            result = self._execute(
+                """INSERT INTO user_model
+                   (topic, project, familiarity, last_seen, times_seen, times_explained, metadata)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s) RETURNING id""",
+                (uk.topic, uk.project, uk.familiarity, uk.last_seen,
+                 uk.times_seen, uk.times_explained, self._to_json(uk.metadata)),
+                returning=True,
+            )
+            if result:
+                uk.id = result[0]
+        return uk
+
+    def get_user_knowledge(self, topic: str, project: str = "") -> Optional[UserKnowledge]:
+        row = self._query_one(
+            "SELECT * FROM user_model WHERE topic = %s AND project = %s",
+            (topic, project),
+        )
+        if not row:
+            return None
+        return UserKnowledge(
+            id=row["id"], topic=row["topic"], project=row["project"],
+            familiarity=row["familiarity"], last_seen=row["last_seen"],
+            times_seen=row["times_seen"], times_explained=row["times_explained"],
+            metadata=self._from_json(row["metadata"], {}),
+        )
+
+    def list_user_knowledge(self, project: Optional[str] = None) -> list[UserKnowledge]:
+        if project:
+            rows = self._query(
+                "SELECT * FROM user_model WHERE project = %s ORDER BY familiarity DESC",
+                (project,),
+            )
+        else:
+            rows = self._query("SELECT * FROM user_model ORDER BY familiarity DESC")
+        return [
+            UserKnowledge(
+                id=r["id"], topic=r["topic"], project=r["project"],
+                familiarity=r["familiarity"], last_seen=r["last_seen"],
+                times_seen=r["times_seen"], times_explained=r["times_explained"],
+                metadata=self._from_json(r["metadata"], {}),
+            )
+            for r in rows
+        ]
+
+    # --- Episode helpers ---
+
+    def update_episode_access(self, episode_id: str, reinforcement_count: int, last_accessed: str) -> None:
+        self._execute(
+            "UPDATE episodes SET reinforcement_count = %s, last_accessed = %s WHERE id = %s",
+            (reinforcement_count, last_accessed, episode_id),
+        )
+
+    def list_episodes_for_pruning(
+        self, min_age_days: int = 30, consolidated: int = 1, limit: int = 500,
+    ) -> list[Episode]:
+        rows = self._query(
+            """SELECT * FROM episodes
+               WHERE consolidated = %s
+               AND timestamp::timestamptz < NOW() - make_interval(days => %s)
+               ORDER BY timestamp ASC LIMIT %s""",
+            (consolidated, min_age_days, limit),
+        )
+        return [self._row_to_episode(r) for r in rows]
+
+    # --- Theory helpers ---
+
+    def list_children_of_theory(self, parent_id: str) -> list[Theory]:
+        rows = self._query(
+            "SELECT * FROM theories WHERE parent_theory_id = %s AND active = TRUE",
+            (parent_id,),
+        )
+        return [self._row_to_theory(r) for r in rows]
+
+    # --- Causal Links ---
+
+    def save_causal_link(self, link: CausalLink) -> CausalLink:
+        norm_cause = self._normalize_text(link.cause_text)
+        norm_effect = self._normalize_text(link.effect_text)
+        if link.id is not None:
+            self._execute(
+                """UPDATE causal_links SET cause_text=%s, effect_text=%s, mechanism=%s,
+                   mechanism_detail=%s, confidence_level=%s, strength=%s,
+                   observation_count=%s, source_episode_ids=%s, source_theory_id=%s,
+                   project=%s, updated_at=%s,
+                   cause_text_normalized=%s, effect_text_normalized=%s
+                   WHERE id=%s""",
+                (link.cause_text, link.effect_text, link.mechanism,
+                 link.mechanism_detail, link.confidence_level, link.strength,
+                 link.observation_count, self._to_json(link.source_episode_ids),
+                 link.source_theory_id, link.project, link.updated_at,
+                 norm_cause, norm_effect, link.id),
+            )
+        else:
+            result = self._execute(
+                """INSERT INTO causal_links
+                   (cause_text, effect_text, mechanism, mechanism_detail,
+                    confidence_level, strength, observation_count,
+                    source_episode_ids, source_theory_id, project,
+                    created_at, updated_at,
+                    cause_text_normalized, effect_text_normalized)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) RETURNING id""",
+                (link.cause_text, link.effect_text, link.mechanism,
+                 link.mechanism_detail, link.confidence_level, link.strength,
+                 link.observation_count, self._to_json(link.source_episode_ids),
+                 link.source_theory_id, link.project,
+                 link.created_at, link.updated_at, norm_cause, norm_effect),
+                returning=True,
+            )
+            if result:
+                link.id = result[0]
+        return link
+
+    def get_causal_link(self, link_id: int) -> Optional[CausalLink]:
+        row = self._query_one("SELECT * FROM causal_links WHERE id = %s", (link_id,))
+        return self._row_to_causal_link(row) if row else None
+
+    def list_causal_links(
+        self, cause_text: Optional[str] = None, effect_text: Optional[str] = None,
+        project: Optional[str] = None, limit: int = 100,
+    ) -> list[CausalLink]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if cause_text is not None:
+            clauses.append("cause_text = %s")
+            params.append(cause_text)
+        if effect_text is not None:
+            clauses.append("effect_text = %s")
+            params.append(effect_text)
+        if project is not None:
+            clauses.append("project = %s")
+            params.append(project)
+        where = " AND ".join(clauses) if clauses else "TRUE"
+        params.append(limit)
+        rows = self._query(
+            f"SELECT * FROM causal_links WHERE {where} ORDER BY observation_count DESC LIMIT %s",
+            params,
+        )
+        return [self._row_to_causal_link(r) for r in rows]
+
+    def find_causal_links_by_text(self, text: str, role: str = "cause") -> list[CausalLink]:
+        column = "cause_text" if role == "cause" else "effect_text"
+        rows = self._query(
+            f"SELECT * FROM causal_links WHERE {column} ILIKE %s ORDER BY observation_count DESC",
+            (f"%{text}%",),
+        )
+        return [self._row_to_causal_link(r) for r in rows]
+
+    def increment_causal_observation(self, link_id: int) -> None:
+        self._execute(
+            "UPDATE causal_links SET observation_count = observation_count + 1, updated_at = %s WHERE id = %s",
+            (_utcnow(), link_id),
+        )
+
+    def count_causal_links(self) -> int:
+        row = self._query_one("SELECT COUNT(*) AS cnt FROM causal_links")
+        return row["cnt"] if row else 0
+
+    def list_causal_links_normalized(
+        self, cause_text: str, effect_text: str, limit: int = 5,
+    ) -> list[CausalLink]:
+        norm_cause = self._normalize_text(cause_text)
+        norm_effect = self._normalize_text(effect_text)
+        rows = self._query(
+            """SELECT * FROM causal_links
+               WHERE cause_text_normalized = %s AND effect_text_normalized = %s
+               ORDER BY observation_count DESC LIMIT %s""",
+            (norm_cause, norm_effect, limit),
+        )
+        return [self._row_to_causal_link(r) for r in rows]
+
+    def _row_to_causal_link(self, row: dict[str, Any]) -> CausalLink:
+        return CausalLink(
+            id=row["id"], cause_text=row["cause_text"],
+            effect_text=row["effect_text"], mechanism=row["mechanism"],
+            mechanism_detail=row["mechanism_detail"] or "",
+            confidence_level=row["confidence_level"] or "observed",
+            strength=row["strength"], observation_count=row["observation_count"],
+            source_episode_ids=self._from_json(row["source_episode_ids"], []),
+            source_theory_id=row["source_theory_id"] or "",
+            project=row["project"] or "",
+            created_at=row["created_at"], updated_at=row["updated_at"],
+        )
+
+    # --- Junction tables ---
+
+    def add_theory_episode(self, theory_id: str, episode_id: str) -> None:
+        self._execute(
+            "INSERT INTO theory_episodes (theory_id, episode_id) VALUES (%s, %s) ON CONFLICT DO NOTHING",
+            (theory_id, episode_id),
+        )
+
+    def get_theory_episode_ids(self, theory_id: str) -> list[str]:
+        rows = self._query(
+            "SELECT episode_id FROM theory_episodes WHERE theory_id = %s", (theory_id,)
+        )
+        return [r["episode_id"] for r in rows]
+
+    def get_theories_for_episode(self, episode_id: str) -> list[str]:
+        rows = self._query(
+            "SELECT theory_id FROM theory_episodes WHERE episode_id = %s", (episode_id,)
+        )
+        return [r["theory_id"] for r in rows]
+
+    def add_theory_relation(self, theory_id: str, related_id: str) -> None:
+        self._execute(
+            "INSERT INTO theory_relations (theory_id, related_theory_id) VALUES (%s, %s) ON CONFLICT DO NOTHING",
+            (theory_id, related_id),
+        )
+
+    def get_related_theory_ids(self, theory_id: str) -> list[str]:
+        rows = self._query(
+            "SELECT related_theory_id FROM theory_relations WHERE theory_id = %s", (theory_id,)
+        )
+        return [r["related_theory_id"] for r in rows]
+
+    def add_causal_link_episode(self, link_id: int, episode_id: str) -> None:
+        self._execute(
+            "INSERT INTO causal_link_episodes (causal_link_id, episode_id) VALUES (%s, %s) ON CONFLICT DO NOTHING",
+            (link_id, episode_id),
+        )
+
+    def get_causal_link_episode_ids(self, link_id: int) -> list[str]:
+        rows = self._query(
+            "SELECT episode_id FROM causal_link_episodes WHERE causal_link_id = %s", (link_id,)
+        )
+        return [r["episode_id"] for r in rows]
+
+    def set_entity_fingerprints(self, entity_id: str, entity_type: str, patterns: list[str]) -> None:
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM entity_fingerprints WHERE entity_id = %s AND entity_type = %s",
+                    (entity_id, entity_type),
+                )
+                for pattern in patterns:
+                    if pattern:
+                        cur.execute(
+                            "INSERT INTO entity_fingerprints (entity_id, entity_type, pattern) VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
+                            (entity_id, entity_type, pattern),
+                        )
+                conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            self._put_conn(conn)
+
+    def get_entity_fingerprints(self, entity_id: str, entity_type: str) -> list[str]:
+        rows = self._query(
+            "SELECT pattern FROM entity_fingerprints WHERE entity_id = %s AND entity_type = %s",
+            (entity_id, entity_type),
+        )
+        return [r["pattern"] for r in rows]
+
+    def find_entities_by_fingerprint(self, pattern: str, entity_type: Optional[str] = None) -> list[dict[str, str]]:
+        if entity_type:
+            rows = self._query(
+                "SELECT entity_id, entity_type FROM entity_fingerprints WHERE pattern = %s AND entity_type = %s",
+                (pattern, entity_type),
+            )
+        else:
+            rows = self._query(
+                "SELECT entity_id, entity_type FROM entity_fingerprints WHERE pattern = %s",
+                (pattern,),
+            )
+        return [{"entity_id": r["entity_id"], "entity_type": r["entity_type"]} for r in rows]
+
+    # --- Bulk-read helpers for graph sync ---
+
+    def list_all_entity_fingerprints(self) -> list[dict[str, str]]:
+        rows = self._query("SELECT entity_id, entity_type, pattern FROM entity_fingerprints")
+        return [{"entity_id": r["entity_id"], "entity_type": r["entity_type"], "pattern": r["pattern"]} for r in rows]
+
+    def list_all_theory_episodes(self) -> list[dict[str, str]]:
+        rows = self._query("SELECT theory_id, episode_id FROM theory_episodes")
+        return [{"theory_id": r["theory_id"], "episode_id": r["episode_id"]} for r in rows]
+
+    def list_all_theory_relations(self) -> list[dict[str, str]]:
+        rows = self._query("SELECT theory_id, related_theory_id FROM theory_relations")
+        return [{"theory_id": r["theory_id"], "related_theory_id": r["related_theory_id"]} for r in rows]
+
+    def list_all_causal_link_episodes(self) -> list[dict[str, Any]]:
+        rows = self._query("SELECT causal_link_id, episode_id FROM causal_link_episodes")
+        return [{"causal_link_id": r["causal_link_id"], "episode_id": r["episode_id"]} for r in rows]
+
+    # --- Failure Records ---
+
+    def save_failure_record(self, record: FailureRecord) -> FailureRecord:
+        if record.id is not None:
+            self._execute(
+                """UPDATE failure_records SET what_failed=%s, why_failed=%s,
+                   what_worked=%s, category=%s, project=%s, context=%s,
+                   source_episode_id=%s, severity=%s, occurrence_count=%s,
+                   last_seen=%s WHERE id=%s""",
+                (record.what_failed, record.why_failed, record.what_worked,
+                 record.category, record.project, record.context,
+                 record.source_episode_id, record.severity, record.occurrence_count,
+                 record.last_seen, record.id),
+            )
+        else:
+            result = self._execute(
+                """INSERT INTO failure_records
+                   (what_failed, why_failed, what_worked, category, project,
+                    context, source_episode_id, severity, occurrence_count,
+                    created_at, last_seen)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) RETURNING id""",
+                (record.what_failed, record.why_failed, record.what_worked,
+                 record.category, record.project, record.context,
+                 record.source_episode_id, record.severity, record.occurrence_count,
+                 record.created_at, record.last_seen),
+                returning=True,
+            )
+            if result:
+                record.id = result[0]
+        return record
+
+    def get_failure_record(self, record_id: int) -> Optional[FailureRecord]:
+        row = self._query_one("SELECT * FROM failure_records WHERE id = %s", (record_id,))
+        if not row:
+            return None
+        return self._row_to_failure_record(row)
+
+    def list_failure_records(
+        self, project: Optional[str] = None, category: Optional[str] = None,
+        min_severity: int = 1, limit: int = 100,
+    ) -> list[FailureRecord]:
+        clauses = ["severity >= %s"]
+        params: list[Any] = [min_severity]
+        if project is not None:
+            clauses.append("project = %s")
+            params.append(project)
+        if category is not None:
+            clauses.append("category = %s")
+            params.append(category)
+        where = " AND ".join(clauses)
+        params.append(limit)
+        rows = self._query(
+            f"SELECT * FROM failure_records WHERE {where} ORDER BY occurrence_count DESC LIMIT %s",
+            params,
+        )
+        return [self._row_to_failure_record(r) for r in rows]
+
+    def increment_failure_occurrence(self, record_id: int) -> None:
+        self._execute(
+            "UPDATE failure_records SET occurrence_count = occurrence_count + 1, last_seen = %s WHERE id = %s",
+            (_utcnow(), record_id),
+        )
+
+    def count_failure_records(self) -> int:
+        row = self._query_one("SELECT COUNT(*) AS cnt FROM failure_records")
+        return row["cnt"] if row else 0
+
+    def _row_to_failure_record(self, row: dict[str, Any]) -> FailureRecord:
+        return FailureRecord(
+            id=row["id"], what_failed=row["what_failed"],
+            why_failed=row["why_failed"] or "",
+            what_worked=row["what_worked"] or "",
+            category=row["category"] or "approach",
+            project=row["project"] or "",
+            context=row["context"] or "",
+            source_episode_id=row["source_episode_id"] or "",
+            severity=row["severity"], occurrence_count=row["occurrence_count"],
+            created_at=row["created_at"], last_seen=row["last_seen"],
+        )
+
+    # --- Stats ---
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "sessions": self._query_one("SELECT COUNT(*) AS cnt FROM sessions")["cnt"],
+            "episodes": {
+                "total": self.count_episodes(),
+                "pending": self.count_episodes(consolidated=0),
+                "consolidated": self.count_episodes(consolidated=1),
+                "decayed": self.count_episodes(consolidated=2),
+            },
+            "theories": {
+                "total": self.count_theories(active_only=False),
+                "active": self.count_theories(active_only=True),
+            },
+            "contradictions": {
+                "total": self.count_contradictions(),
+                "unresolved": self.count_contradictions(unresolved_only=True),
+            },
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "backend": "postgresql",
+        }

--- a/neurosync/signals.py
+++ b/neurosync/signals.py
@@ -1,4 +1,8 @@
-"""Signal weight calculations — 6 signal types that compose into episode weights."""
+"""Signal weight calculations — 8 signal types that compose into episode weights.
+
+Active: CORRECTION, DEPTH, SURPRISE, REPETITION, EXPLICIT, INTUITION, PASSIVE.
+Defined but unwired: DURATION (requires session-level timing data).
+"""
 
 from __future__ import annotations
 
@@ -136,9 +140,19 @@ def compute_episode_signals(
     session_duration: float = 0.0,
     is_explicit: bool = False,
     importance: int = 0,
+    is_passive: bool = False,
 ) -> tuple[list[SignalResult], float]:
-    """Compute all applicable signals for an episode. Returns (signals, composite_weight)."""
+    """Compute all applicable signals for an episode. Returns (signals, composite_weight).
+
+    Active signal types: CORRECTION, DEPTH, SURPRISE, REPETITION, EXPLICIT,
+    INTUITION, PASSIVE. DURATION is defined but requires session-level timing
+    data that is not yet collected.
+    """
     signals: list[SignalResult] = []
+
+    # PASSIVE: auto-observed events (git changes) — always record for audit trail
+    if is_passive or event_type == "observed":
+        signals.append(compute_passive_signal())
 
     if event_type == "correction" and correction_count > 0:
         signals.append(compute_correction_signal(correction_count))

--- a/neurosync/user_model.py
+++ b/neurosync/user_model.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from neurosync.db import Database
 from neurosync.models import UserKnowledge, _utcnow
 
 
 class UserModel:
-    """Tracks user familiarity with topics to avoid re-explaining known concepts."""
+    """Tracks user familiarity with topics to avoid re-explaining known concepts.
+
+    Also provides meta-learning: tracks correction rates per topic to measure
+    skill progression over time (declining correction rate = learning).
+    """
 
     def __init__(self, db: Database) -> None:
         self._db = db
@@ -33,6 +37,26 @@ class UserModel:
 
         return self._db.save_user_knowledge(uk)
 
+    def record_correction_on_topic(self, topic: str, project: str = "") -> UserKnowledge:
+        """Record a correction related to a topic — tracks correction frequency.
+
+        Corrections reduce familiarity slightly (we were wrong about this topic).
+        Metadata tracks correction_count for meta-learning analysis.
+        """
+        uk = self._db.get_user_knowledge(topic, project)
+        if uk is None:
+            uk = UserKnowledge(topic=topic, project=project, familiarity=0.3)
+
+        uk.last_seen = _utcnow()
+        # Correction means we're less familiar than we thought
+        uk.familiarity = max(0.0, uk.familiarity - 0.1)
+        # Track correction count in metadata for meta-learning
+        correction_count = uk.metadata.get("correction_count", 0) + 1
+        uk.metadata["correction_count"] = correction_count
+        uk.metadata["last_correction"] = _utcnow()
+
+        return self._db.save_user_knowledge(uk)
+
     def get_familiarity(self, topic: str, project: str = "") -> float:
         """Get user's familiarity with a topic (0.0 to 1.0)."""
         uk = self._db.get_user_knowledge(topic, project)
@@ -51,3 +75,32 @@ class UserModel:
 
     def list_knowledge(self, project: Optional[str] = None) -> list[UserKnowledge]:
         return self._db.list_user_knowledge(project=project)
+
+    def get_skill_progression(self, project: Optional[str] = None) -> dict[str, Any]:
+        """Analyze skill progression: topics where correction rate is declining.
+
+        Returns topics grouped by learning stage:
+        - mastered: high familiarity, few recent corrections
+        - learning: growing familiarity, declining corrections
+        - struggling: low familiarity, frequent corrections
+        """
+        all_knowledge = self._db.list_user_knowledge(project=project)
+        mastered: list[str] = []
+        learning: list[str] = []
+        struggling: list[str] = []
+
+        for uk in all_knowledge:
+            corrections = uk.metadata.get("correction_count", 0)
+            if uk.familiarity >= 0.8 and corrections <= 1:
+                mastered.append(uk.topic)
+            elif uk.familiarity >= 0.4:
+                learning.append(uk.topic)
+            elif corrections >= 2:
+                struggling.append(uk.topic)
+
+        return {
+            "mastered": mastered,
+            "learning": learning,
+            "struggling": struggling,
+            "total_topics": len(all_knowledge),
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dev = [
 neo4j = [
     "neo4j>=5.0",
 ]
+postgresql = [
+    "psycopg2-binary>=2.9",
+]
 
 [project.scripts]
 neurosync = "neurosync.cli:main"
@@ -49,7 +52,7 @@ markers = [
 
 [tool.coverage.run]
 source = ["neurosync"]
-omit = ["neurosync/starter_packs/*.py"]
+omit = ["neurosync/starter_packs/*.py", "neurosync/pg_db.py"]
 
 [tool.coverage.report]
 fail_under = 85


### PR DESCRIPTION
## Summary

  Wire three dead-code engines (ForgettingEngine, UserModel, RetrievalPipeline) into the MCP server, activate 7 of 8 signal types, replace naive consolidation with zero-LLM TF-IDF/causal-merge heuristics, add optional PostgreSQL backend, fix 8 defects found during
  critical review, and update all 8 documentation files to reflect the new architecture.

  ## Related issue

  Fixes #1 

  ## Type of change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Test improvement (no production code changes)

  ## Changes

  **Backend — wire dead code:**
  - `RetrievalPipeline` replaces `WorkingMemory` for recall in `handle_recall`, adding familiarity filtering, parent context, and continuation priority
  - `ForgettingEngine` runs Ebbinghaus decay pass after every consolidation in `_try_auto_consolidate`
  - `UserModel` tracks topic familiarity and correction rate, wired into `handle_recall`, `handle_record`, and `handle_correct`
  - All 7 active signal types now fire via `compute_episode_signals()` (CORRECTION, DEPTH, SURPRISE, REPETITION, EXPLICIT, INTUITION, PASSIVE); DURATION is defined but unwired (requires session-level timing)
  - `handle_remember` now uses `importance`, `reasoning`, `cause`, `effect` parameters instead of discarding them

  **Backend — consolidation improvements (zero LLM):**
  - 3-strategy theory extraction: causal merge for episodes with cause/effect fields, TF-IDF keyword extraction for clusters of 3+, fallback to highest-weight episode
  - MDL threshold fixed from 5.0 (no-op — a theory can never be 5x longer than its source episodes) to 0.7
  - Removed competing linear decay from `consolidation.py`; Ebbinghaus in `ForgettingEngine` is now the sole decay system

  **Backend — PostgreSQL backend (`pg_db.py`):**
  - New `PostgresDatabase` class with same public interface as `db.Database`
  - Uses `psycopg2.pool.ThreadedConnectionPool`, JSONB columns, `ON CONFLICT` upserts
  - Auto-fallback to SQLite if PostgreSQL unavailable
  - Credentials (`NEUROSYNC_PG_DSN`) only from env vars, never `config.json`

  **Review fixes (8 defects):**
  1. `_apply_outcome_confidence_adjustment` now filters by topic-relevance (keyword overlap between correction text and theory content) instead of blanket-penalizing all active theories — follows Hebbian specificity
  2. `_has_contradiction_language` now requires strong multi-word phrases (e.g., "but actually", "this is wrong") or co-occurrence of 2+ weak indicators — eliminates false positive SURPRISE signals from normal technical writing
  3. CORRECTION signal path decoupled: `record_correction` passes `correction_count` through to `record_episode` → `compute_episode_signals` instead of manually creating a `Signal` record, removing the fragile double-save possibility
  4. PASSIVE signal now saves `SignalResult` records via `compute_episode_signals` when `event_type == "observed"`, completing the signal audit trail
  5. `pg_db.py` INTERVAL syntax fixed: `INTERVAL '%s days'` (string-literal parameterization) replaced with `make_interval(days => %s)` for proper PostgreSQL compatibility
  6. Frontend overview query rewritten: `MATCH (n) OPTIONAL MATCH (n)-[r]->(m) LIMIT 500` (Cartesian product) replaced with `MATCH (n)-[r]->(m) LIMIT 1000 UNION ALL MATCH (orphan) WHERE NOT (orphan)--() LIMIT 100`
  7. Project filter dropdown added to Sidebar: extracts unique projects from `node.properties.project`, filters nodes by session membership + direct links
  8. Animation loop adds idle detection: `requestAnimationFrame` pauses after 5s of no interaction, wakes on mousemove/mousedown/wheel/touchstart or graph data changes

  **Documentation — 8 files updated:**
  - `CLAUDE.md`: removed duplicate `user_model.py`/`retrieval.py` entries, fixed "All 8 signal types" → "7 active", added Database Backends section with PostgreSQL
  - `README.md`: added `pg_db.py` + 5 missing cognitive modules to project tree, added PostgreSQL Backend section, updated tech stack table, fixed version refs 0.4.0 → 0.5.0
  - `docs/architecture.md`: expanded signal table to 8 rows with status column, rewrote consolidation pipeline with 3 strategies and ForgettingEngine, added Database Backends section, expanded recall to 9 steps with RetrievalPipeline
  - `docs/data-flow.md`: rewrote Recording (all 7 signals + outcome confidence), Recall (RetrievalPipeline + UserModel + ForgettingEngine), Consolidation (TF-IDF + causal merge), and Confidence Lifecycle (Ebbinghaus formula)
  - `docs/mcp-tools.md`: complete rewrite — added `neurosync_handoff` and `neurosync_graph` (were entirely missing), added missing params (`importance`, `reasoning`, `cause`, `effect`, `mode`), added `relate`/`graph` actions to `neurosync_theories`
  - `CONTRIBUTING.md`: expanded module map from 12 to 20 entries, updated architecture overview with full data flow, updated commit scopes, added PostgreSQL to setup
  - `docs/skill-setup.md`: added `graph-sync`/`graph-status` to quick reference
  - `docs/setup.md`: already updated in prior session (PostgreSQL + frontend sections)

  ## How to test

  1. `pip install -e ".[dev]"` and run `pytest --cov=neurosync -v` — 368 tests pass, 86%+ coverage
  2. `ruff check neurosync/` — all checks passed
  3. `cd frontend && npx tsc --noEmit` — TypeScript compiles cleanly
  4. `cd frontend && npm run build` — production build succeeds
  5. To test PostgreSQL backend: `export NEUROSYNC_DB_BACKEND=postgresql NEUROSYNC_PG_DSN=postgresql://postgres:pass@localhost:5432/neurosync` and run the MCP server — it should connect and create tables automatically
  6. To test the frontend: `cd frontend && npm run dev`, open localhost:5173, connect to Neo4j, verify project filter dropdown appears and animation pauses after 5s idle

  ## Checklist

  - [x] Tests pass locally: `pytest --cov=neurosync -v`
  - [x] Lint passes: `ruff check neurosync/`
  - [x] Coverage >= 85% (86.19%)
  - [ ] New code has tests
  - [x] No new dependencies added (or discussed in issue first)
  - [x] `CLAUDE.md` updated if architecture or tool behavior changed
  - [x] Commit messages follow [conventional format](#commit-messages)

  Note on the "New code has tests" checkbox: It's intentionally left unchecked. The pg_db.py file is excluded from coverage (requires a real PostgreSQL instance), and the new wiring in mcp_server.py (outcome confidence adjustment, topic overlap, contradiction language)
  doesn't have dedicated tests yet. The existing 368 tests cover the engines themselves, but the new integration points in the MCP handlers would benefit from additional test coverage in a follow-up.